### PR TITLE
Reconcile implemented endpoints with OpenAPI spec

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -581,8 +581,16 @@ components:
           type: integer
         id:
           type: string
+        # FIXME: Including the text paragraphs will not perform on the corpus
+        # level which is why the property is optional for now. We should
+        # consider removing it and finding an alternative why to access the
+        # text. How about providing a link to the TEI with the paragraph ID as
+        # fragment identifier.
         text:
           type: string
+      required:
+        - frequency
+        - id
     EntityMetrics:
       type: object
       properties:
@@ -594,6 +602,9 @@ components:
             $ref: '#/components/schemas/Occurrence'
         overallFrequency:
           type: integer
+      required:
+        - occurrences
+        - overallFrequency
     Entity:
       type: object
       properties:

--- a/api.yaml
+++ b/api.yaml
@@ -9,9 +9,11 @@ info:
   license:
     name: "Apache 2.0"
     url: "http://www.apache.org/licenses/LICENSE-2.0.html"
+
 servers:
   - description: Production
     url: https://ecocor.org/api
+
 tags:
   - name: meta
     description: Information about this service.
@@ -23,6 +25,7 @@ tags:
     description: Analyze occurrences of animals and plants in corpora and texts.
   - name: admin
     description: Manage corpora.
+
 paths:
   /info:
     get:
@@ -46,6 +49,7 @@ paths:
                   "status": "beta",
                   "version": "1.0.0"
                 }
+
   /corpora:
     get:
       summary: List available corpora
@@ -298,13 +302,14 @@ paths:
           description: Text has been removed
         '404':
           description: No such text under this URI
+
   /entities/{wikidataId}:
     get:
       summary: Get single entity
       description: Get a single entity by its identifier on Wikidata.
       operationId: get-entity
       tags:
-      - entities
+        - entities
       parameters:
         - $ref: "#/components/parameters/entityWikidataId"
       responses:
@@ -314,16 +319,17 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Entity'
+
   /corpora/{corpusname}/entities:
     get:
       summary: Get entities of a single corpus
       description: Optionally filter by entity type.
       operationId: get-corpus-entities
       tags:
-      - entities
+        - entities
       parameters:
-      - $ref: "#/components/parameters/corpusname"
-      - $ref: "#/components/parameters/entityType"
+        - $ref: "#/components/parameters/corpusname"
+        - $ref: "#/components/parameters/entityType"
       responses:
         '200':
           description: entity
@@ -333,17 +339,18 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Entity'
+
   /corpora/{corpusname}/texts/{textname}/entities:
     get:
       summary: Get entities of a single text
       description: Optionally filter by entity type.
       operationId: get-text-entities
       tags:
-      - entities
+        - entities
       parameters:
-      - $ref: "#/components/parameters/corpusname"
-      - $ref: "#/components/parameters/textname"
-      - $ref: "#/components/parameters/entityType"
+        - $ref: "#/components/parameters/corpusname"
+        - $ref: "#/components/parameters/textname"
+        - $ref: "#/components/parameters/entityType"
       responses:
         '200':
           description: entity
@@ -353,6 +360,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Entity'
+
 components:
   parameters:
     corpusname:

--- a/api.yaml
+++ b/api.yaml
@@ -386,7 +386,7 @@ components:
       required: true
       description: >
         Short name of the corpus as provided in the `name` property of the result
-        objects from the [/corpora](#/public/list-corpora) endpoint
+        objects from the [/corpora](#/corpus/get-corpora) endpoint
       schema:
         type: string
       examples:
@@ -403,7 +403,7 @@ components:
       description: >
         Name parameter (or "slug") of the text as provided in the `name`
         property of the result objects of the
-        [/corpora/{corpusname}](#/public/list-corpus-content) endpoint.
+        [/corpora/{corpusname}/texts](#/corpus/get-corpus-texts) endpoint.
       schema:
         type: string
       examples:

--- a/api.yaml
+++ b/api.yaml
@@ -272,8 +272,8 @@ paths:
 
   /corpora/{corpusname}/texts/{textname}:
     get:
-      summary: Get a single text
-      description: Get a single text as TEI-XML or metadata about a text in JSON format.
+      summary: Get a single text information
+      description: Get metadata about an individual text in JSON format.
       operationId: get-text
       tags: [text]
       parameters:
@@ -302,6 +302,23 @@ paths:
           description: Text has been removed
         '404':
           description: No such text under this URI
+
+  /corpora/{corpusname}/texts/{textname}/tei:
+    get:
+      summary: Get a single text
+      description: Get a single text as TEI XML.
+      operationId: get-text-tei
+      parameters:
+        - $ref: "#/components/parameters/corpusname"
+        - $ref: "#/components/parameters/textname"
+      tags: [text]
+      responses:
+        '200':
+          description: Returns an TEI XML document
+          content:
+            application/tei+xml:
+              schema:
+                type: string
 
   /entities/{wikidataId}:
     get:

--- a/api.yaml
+++ b/api.yaml
@@ -70,14 +70,30 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Corpus'
-
               example:
                 [
                   {
                     "name": "en",
                     "title": "English EcoCor",
                     "repository": "https://github.com/dracor-org/eco_en",
-                    "uri": "https://ecocor.org/api/corpora/en",
+                    "description": "See the [README on GitHub](https://github.com/dracor-org/eco_en).",
+                    "licence": "CC0",
+                    "licenceUrl": "https://creativecommons.org/share-your-work/public-domain/cc0/",
+                    "uri": "http://ecocor.org/api/corpora/en",
+                    "entitiesUrl": "http://ecocor.org/api/corpora/en/entities",
+                    "textsUrl": "http://ecocor.org/api/corpora/en/texts",
+                    "metrics": {
+                      "numOfTexts": 23,
+                      "numOfAuthors": 21,
+                      "numOfParagraphs": 46457,
+                      "numOfWords": 2346818.0,
+                      "numOfEntities": 261,
+                      "numOfEntityTypes": 3,
+                      "numOfAnimals": 245,
+                      "numOfPlants": 16,
+                      "biodiversityIndex": 0
+                    },
+                    "updated": "2023-06-02T13:52:54.934Z"
                   }
                 ]
     post:
@@ -165,6 +181,30 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Corpus'
+              example:
+                {
+                  "name": "en",
+                  "title": "English EcoCor",
+                  "repository": "https://github.com/dracor-org/eco_en",
+                  "description": "See the [README on GitHub](https://github.com/dracor-org/eco_en).",
+                  "licence": "CC0",
+                  "licenceUrl": "https://creativecommons.org/share-your-work/public-domain/cc0/",
+                  "uri": "http://ecocor.org/api/corpora/en",
+                  "entitiesUrl": "http://ecocor.org/api/corpora/en/entities",
+                  "textsUrl": "http://ecocor.org/api/corpora/en/texts",
+                  "metrics": {
+                    "numOfTexts": 23,
+                    "numOfAuthors": 21,
+                    "numOfParagraphs": 46457,
+                    "numOfWords": 2346818.0,
+                    "numOfEntities": 261,
+                    "numOfEntityTypes": 3,
+                    "numOfAnimals": 245,
+                    "numOfPlants": 16,
+                    "biodiversityIndex": 0
+                  },
+                  "updated": "2023-06-02T13:52:54.934Z"
+                }
         '404':
           description: Corpus not found
     post:
@@ -379,24 +419,36 @@ components:
     CorpusMetrics:
       type: object
       properties:
+        numOfTexts:
+          type: integer
         numOfParagraphs:
+          type: integer
+        numOfWords:
+          type: integer
+        numOfAuthors:
+          type: integer
+        numOfEntities:
           type: integer
         numOfEntityTypes:
           type: integer
         biodiversityIndex:
           type: number
-        numOfTexts:
-          type: integer
-        updated:
-          type: string
-        numOfEntities:
-          type: integer
     Corpus:
       type: object
       properties:
+        name:
+          type: string
+        title:
+          type: string
+        acronym:
+          type: string
+        description:
+          type: string
         repository:
           type: string
           format: url
+        licence:
+          type: string
         licenceUrl:
           type: string
           format: url
@@ -405,17 +457,18 @@ components:
         textsUrl:
           type: string
           format: url
-        description:
-          type: string
-        licence:
-          type: string
-        title:
-          type: string
         entitiesUrl:
           type: string
           format: url
-        corpusname:
+        updated:
           type: string
+      required:
+        - name
+        - title
+        - repository
+        - textsUrl
+        - entitiesUrl
+        - updated
     ExternalReferenceResourceId:
       type: object
       properties:

--- a/api.yaml
+++ b/api.yaml
@@ -495,18 +495,41 @@ components:
     TextMetrics:
       type: object
       properties:
+        numOfChapters:
+          type: integer
         numOfParagraphs:
+          type: integer
+        numOfWords:
+          type: integer
+        numOfEntities:
           type: integer
         numOfEntityTypes:
           type: integer
         biodiversityIndex:
           type: number
-        numOfChapters:
-          type: integer
-        numOfWordTokens:
-          type: integer
-        numOfEntities:
-          type: integer
+    Author:
+      type: object
+      properties:
+        name:
+          type: string
+        ref:
+          type: string
+          format: url
+          description: Wikidata URI
+        gender:
+          type: string
+      required:
+        - name
+    DigitalSource:
+      type: object
+      properties:
+        url:
+          type: string
+          format: url
+        name:
+          type: string
+      required:
+        - url
     PrintSource:
       type: object
       properties:
@@ -518,27 +541,6 @@ components:
           type: integer
         title:
           type: string
-    Author:
-      type: object
-      properties:
-        refs:
-          type: array
-          items:
-            $ref: '#/components/schemas/ExternalReferenceResourceId'
-        name:
-          type: string
-        gender:
-          type: string
-    DigitalSource:
-      type: object
-      properties:
-        url:
-          type: string
-          format: url
-          nullable: true
-        name:
-          type: string
-          nullable: true
     Dates:
       type: object
       properties:
@@ -554,34 +556,49 @@ components:
     Text:
       type: object
       properties:
-        refs:
-          type: array
-          items:
-            $ref: '#/components/schemas/ExternalReferenceResourceId'
-        metrics:
-          $ref: '#/components/schemas/TextMetrics'
-        textname:
-          type: string
-        printedSource:
-          $ref: '#/components/schemas/PrintSource'
         id:
+          type: string
+        name:
+          type: string
+        corpus:
+          type: string
+        title:
           type: string
         authors:
           type: array
           items:
             $ref: '#/components/schemas/Author'
+        ref:
+          type: string
+          format: url
+          description: Wikidata URI for text
+        # FIXME do we need a refs array?
+        # refs:
+        #   type: array
+        #   items:
+        #     $ref: '#/components/schemas/ExternalReferenceResourceId'
+        digitalSource:
+          $ref: '#/components/schemas/DigitalSource'
+        printedSource:
+          $ref: '#/components/schemas/PrintSource'
+        dates:
+          $ref: '#/components/schemas/Dates'
+        metrics:
+          $ref: '#/components/schemas/TextMetrics'
         corpusUrl:
           type: string
           format: url
-        title:
-          type: string
-        digitalSource:
-          $ref: '#/components/schemas/DigitalSource'
         entitiesUrl:
           type: string
           format: url
-        dates:
-          $ref: '#/components/schemas/Dates'
+      required:
+        - id
+        - name
+        - title
+        - corpus
+        - matrics
+        - corpusUrl
+        - entitiesUrl
     Occurrence:
       type: object
       properties:

--- a/api.yaml
+++ b/api.yaml
@@ -56,15 +56,6 @@ paths:
       description: Get a list of available corpora. Optionally include corpus metrics.
       operationId: get-corpora
       tags: [corpus]
-      parameters:
-        - name: include
-          in: query
-          description: Include metrics for each corpus
-          required: false
-          schema:
-            type: string
-            enum:
-            - metrics
       responses:
         '200':
           description: Returns list of available corpora

--- a/api.yaml
+++ b/api.yaml
@@ -409,10 +409,10 @@ components:
       schema:
         type: string
       examples:
-        animal:
-          value: animal
-        plant:
-          value: plant
+        Animal:
+          value: Animal
+        Plant:
+          value: Plant
     entityWikidataId:
       name: wikidataId
       description: Wikidata identifier of an entity (Q Number).

--- a/modules/api.xqm
+++ b/modules/api.xqm
@@ -587,6 +587,31 @@ function api:text-delete($corpusname, $textname, $data, $auth) {
 };
 
 (:~
+ : Get entities for a single text
+ :
+ : @param $corpusname Corpus name
+ : @param $textname Text name
+ : @result JSON object with entities data
+ :)
+declare
+  %rest:GET
+  %rest:path("/ecocor/corpora/{$corpusname}/texts/{$textname}/entities")
+  %rest:query-param("type", "{$type}")
+  %rest:produces("application/json")
+  %output:media-type("application/json")
+  %output:method("json")
+function api:text-entities($corpusname, $textname, $type) {
+  let $entities := entities:text($corpusname, $textname, $type)
+  return
+    if (count($entities)) then
+      $entities
+    else
+      <rest:response>
+        <http:response status="404"/>
+      </rest:response>
+};
+
+(:~
  : Get TEI document for a single text
  :
  : @param $corpusname Corpus name

--- a/modules/api.xqm
+++ b/modules/api.xqm
@@ -566,7 +566,7 @@ declare
   %rest:path("/ecocor/corpora/{$corpusname}/texts/{$textname}")
   %rest:header-param("Authorization", "{$auth}")
   %output:method("json")
-function api:play-delete($corpusname, $textname, $data, $auth) {
+function api:text-delete($corpusname, $textname, $data, $auth) {
   if (not($auth)) then
     <rest:response>
       <http:response status="401"/>

--- a/modules/api.xqm
+++ b/modules/api.xqm
@@ -586,6 +586,30 @@ function api:play-delete($corpusname, $textname, $data, $auth) {
 };
 
 (:~
+ : Get TEI document for a single text
+ :
+ : @param $corpusname Corpus name
+ : @param $textname Text name
+ : @result XML document
+ :)
+declare
+  %rest:GET
+  %rest:path("/ecocor/corpora/{$corpusname}/texts/{$textname}/tei")
+  %rest:produces("application/xml")
+  %output:media-type("application/xml")
+  %output:method("xml")
+function api:text-tei($corpusname, $textname) {
+  let $doc := ecutil:get-doc($corpusname, $textname)
+  return
+    if (count($doc)) then
+      $doc/tei:TEI
+    else
+      <rest:response>
+        <http:response status="404"/>
+      </rest:response>
+};
+
+(:~
  : Get segments for a single text
  :
  : This provides a JSON object that can serve as payload for the extractor

--- a/modules/api.xqm
+++ b/modules/api.xqm
@@ -448,10 +448,11 @@ function api:corpus-texts($corpusname) {
 declare
   %rest:GET
   %rest:path("/ecocor/corpora/{$corpusname}/entities")
+  %rest:query-param("type", "{$type}")
   %rest:produces("application/json")
   %output:media-type("application/json")
   %output:method("json")
-function api:corpus-entities($corpusname) {
+function api:corpus-entities($corpusname, $type) {
   let $corpus := ectei:get-corpus-info-by-name($corpusname)
   let $collection := concat($config:data-root, "/", $corpusname)
   return
@@ -460,7 +461,7 @@ function api:corpus-entities($corpusname) {
         <http:response status="404"/>
       </rest:response>
     else
-      entities:corpus($corpusname)
+      entities:corpus($corpusname, $type)
 };
 
 (:~

--- a/modules/entities.xqm
+++ b/modules/entities.xqm
@@ -148,11 +148,23 @@ declare function entities:corpus($corpusname as xs:string) {
   let $col := collection($config:entities-root || '/' || $corpusname)
   let $ids := distinct-values($col//entities/entity/wikidata)
   return array {
-    for $id in $ids return
-    map {
-      "id": $id,
-      "name": $col//entities/entity[wikidata=$id][1]/name[1]/text(),
-      "count": sum($col//entities/entity[wikidata=$id]/segments/segment/count)
-    }
+    for $id in $ids
+    let $entities := $col//entities/entity[wikidata=$id]
+    return
+      map {
+        "id": $id,
+        "name": $entities[1]/name[1]/text(),
+        "metrics": map {
+          "overallFrequency": sum($entities/segments/segment/count),
+          "occurrences": array {
+            for $seg in $entities/segments/segment
+            let $f := $seg/count/text()
+            return map {
+              "id": $seg/id/text(),
+              "frequency": if (number($f)) then xs:integer($f) else ()
+            }
+          }
+        }
+      }
   }
 };

--- a/modules/entities.xqm
+++ b/modules/entities.xqm
@@ -143,10 +143,15 @@ declare function entities:update() as xs:string* {
 (:~
  : List entities occurring in a corpus
 :)
-declare function entities:corpus($corpusname as xs:string) {
+declare function entities:corpus(
+  $corpusname as xs:string,
+  $type as xs:string*
+) {
   let $corpus := ectei:get-corpus-info-by-name($corpusname)
   let $col := collection($config:entities-root || '/' || $corpusname)
-  let $ids := distinct-values($col//entities/entity/wikidata)
+  let $ids := if ($type) then
+    distinct-values($col//entities/entity[category=$type]/wikidata)
+    else distinct-values($col//entities/entity/wikidata)
   return array {
     for $id in $ids
     let $entities := $col//entities/entity[wikidata=$id]

--- a/modules/metrics.xqm
+++ b/modules/metrics.xqm
@@ -69,12 +69,14 @@ declare function metrics:corpus ($corpus as xs:string) {
   let $metrics := collection($metrics-uri)
   let $entities := collection(concat($config:entities-root, "/", $corpus))
   return map {
-    "texts": count($col/tei:TEI),
-    "authors": count(distinct-values($col//tei:titleStmt//tei:author)),
-    "words": sum($metrics//words),
-    "entities": count(distinct-values($entities//entities/entity/wikidata)),
-    "animals": count(distinct-values($entities//entities/entity[category="Animal"]/wikidata)),
-    "plants": count(distinct-values($entities//entities/entity[category="Plant"]/wikidata)),
-    "updated": max($metrics//metrics/xs:dateTime(@updated))
+    "numOfTexts": count($col/tei:TEI),
+    "numOfAuthors": count(distinct-values($col//tei:titleStmt//tei:author)),
+    "numOfParagraphs": count($col//tei:body//tei:p),
+    "numOfWords": sum($metrics//words),
+    "numOfEntities": count(distinct-values($entities//entities/entity/wikidata)),
+    "numOfEntityTypes": count(distinct-values($entities//entities/entity/category)),
+    "numOfAnimals": count(distinct-values($entities//entities/entity[category="Animal"]/wikidata)),
+    "numOfPlants": count(distinct-values($entities//entities/entity[category="Plant"]/wikidata)),
+    "biodiversityIndex": 0
   }
 };

--- a/modules/metrics.xqm
+++ b/modules/metrics.xqm
@@ -6,7 +6,7 @@ xquery version "3.1";
 module namespace metrics = "http://ecocor.org/ns/exist/metrics";
 
 import module namespace config = "http://ecocor.org/ns/exist/config" at "config.xqm";
-import module namespace dutil = "http://ecocor.org/ns/exist/util" at "util.xqm";
+import module namespace ecutil = "http://ecocor.org/ns/exist/util" at "util.xqm";
 
 declare namespace tei = "http://www.tei-c.org/ns/1.0";
 
@@ -43,7 +43,7 @@ declare function metrics:calculate($url as xs:string) {
 :)
 declare function metrics:update($url as xs:string) {
   let $metrics := metrics:calculate($url)
-  let $paths := dutil:filepaths($url)
+  let $paths := ecutil:filepaths($url)
   let $collection := $paths?collections?metrics
   let $resource := $paths?filename
   return (
@@ -72,6 +72,25 @@ declare function metrics:corpus ($corpus as xs:string) {
     "numOfTexts": count($col/tei:TEI),
     "numOfAuthors": count(distinct-values($col//tei:titleStmt//tei:author)),
     "numOfParagraphs": count($col//tei:body//tei:p),
+    "numOfWords": sum($metrics//words),
+    "numOfEntities": count(distinct-values($entities//entities/entity/wikidata)),
+    "numOfEntityTypes": count(distinct-values($entities//entities/entity/category)),
+    "numOfAnimals": count(distinct-values($entities//entities/entity[category="Animal"]/wikidata)),
+    "numOfPlants": count(distinct-values($entities//entities/entity[category="Plant"]/wikidata)),
+    "biodiversityIndex": 0
+  }
+};
+
+declare function metrics:text (
+  $corpusname as xs:string,
+  $textname as xs:string
+) {
+  let $doc := ecutil:get-doc($corpusname, $textname)
+  let $metrics := ecutil:get-doc($corpusname, $textname, $config:metrics-root)
+  let $entities := ecutil:get-doc($corpusname, $textname, $config:entities-root)
+  return map {
+    "numOfChapters": count($doc/tei:TEI//tei:text//tei:div[@type = "chapter"]),
+    "numOfParagraphs": count($doc/tei:TEI//tei:body//tei:p),
     "numOfWords": sum($metrics//words),
     "numOfEntities": count(distinct-values($entities//entities/entity/wikidata)),
     "numOfEntityTypes": count(distinct-values($entities//entities/entity/category)),

--- a/modules/tei.xqm
+++ b/modules/tei.xqm
@@ -344,6 +344,19 @@ declare function ectei:get-corpus-text-info(
   return ectei:get-text-info($tei)
 };
 
+(:~
+ : Extract corpus update timestamp from metrics.
+ :
+ : @param $corpusname
+ :)
+declare function ectei:get-corpus-update-time(
+  $corpusname as xs:string
+) as xs:dateTime* {
+  let $metrics-uri := concat($config:metrics-root, "/", $corpusname)
+  let $metrics := collection($metrics-uri)
+  return max($metrics//metrics/xs:dateTime(@updated))
+};
+
 declare function local:to-markdown($input as element()) as item()* {
   for $child in $input/node()
   return
@@ -389,13 +402,16 @@ declare function ectei:get-corpus-info(
       map:entry("uri", $uri),
       map:entry("name", $name),
       map:entry("title", $title),
+      map:entry("textsUrl", $uri || "/texts"),
+      map:entry("entitiesUrl", $uri || "/entities"),
       if ($acronym) then map:entry("acronym", $acronym) else (),
       if ($repo) then map:entry("repository", $repo) else (),
       if ($description) then map:entry("description", $description) else (),
       if ($licence)
         then map:entry("licence", normalize-space($licence)) else (),
       if ($licence/@target)
-        then map:entry("licenceUrl", $licence/@target/string()) else ()
+        then map:entry("licenceUrl", $licence/@target/string()) else (),
+      map:entry("updated", ectei:get-corpus-update-time($name))
     ))
   ) else ()
 };

--- a/modules/tei.xqm
+++ b/modules/tei.xqm
@@ -7,6 +7,7 @@ module namespace ectei = "http://ecocor.org/ns/exist/tei";
 
 import module namespace config = "http://ecocor.org/ns/exist/config" at "config.xqm";
 import module namespace ecutil = "http://ecocor.org/ns/exist/util" at "util.xqm";
+import module namespace metrics = "http://ecocor.org/ns/exist/metrics" at "metrics.xqm";
 
 declare namespace tei = "http://www.tei-c.org/ns/1.0";
 
@@ -286,6 +287,7 @@ declare function ectei:get-text-info($tei as element(tei:TEI)) as map()? {
           "yearNormalized": $year-printed
         })
       else (),
+      map:entry("metrics", metrics:text($paths?corpusname, $paths?textname)),
       map:entry(
         "corpusUrl", $config:api-base || "/corpora/" || $paths?corpusname
       ),

--- a/modules/util.xqm
+++ b/modules/util.xqm
@@ -38,7 +38,23 @@ declare function ecutil:filepaths ($url as xs:string) as map() {
 };
 
 (:~
- : Return document for a text.
+ : Return document for an individual text.
+ :
+ : @param $corpusname
+ : @param $textname
+ : @param $root Path to root directory
+ :)
+declare function ecutil:get-doc(
+  $corpusname as xs:string,
+  $textname as xs:string,
+  $root as xs:string
+) as node()* {
+  doc($root || "/" || $corpusname || "/" || $textname || ".xml")
+};
+
+
+(:~
+ : Return TEI document for an individual text.
  :
  : @param $corpusname
  : @param $textname
@@ -47,10 +63,7 @@ declare function ecutil:get-doc(
   $corpusname as xs:string,
   $textname as xs:string
 ) as node()* {
-  let $doc := doc(
-    $config:data-root || "/" || $corpusname || "/" || $textname || ".xml"
-  )
-  return $doc
+  ecutil:get-doc($corpusname, $textname, $config:data-root)
 };
 
 (:~


### PR DESCRIPTION
This PR tries to bring the endpoint implementations in sync with the [api.yaml](https://github.com/EcoCor/ecocor-api/blob/main/api.yaml). For arriving at a working solution I adjusted both the actual implementation and the OpenAPI spec. In particular I

- adjusted the corpus info implementation
- adjusted/implemented the corpus and text entities endpoints to the spec
- added a dedicated TEI endpoint for single texts
- adjusted the text metrics
- with regard to single text metadata
    - simplified the author information according to what data is actually available in the current corpora (e.g. single ref property,  simple name property)
    - simplified other metadata such as titles and refs
    - added (incomplete) `dates` property
    - added `corpusUrl` and `entitiesUrl` properties

Resolve #13