### PR TITLE
Annotations endpoint

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -355,6 +355,51 @@ paths:
         '404':
           description: Text not found or no annotations subcollection
 
+  /corpora/{corpusname}/texts/{textname}/annotations/{layername}:
+    get:
+      summary: Get a single annotation layer
+      description: >-
+        Returns the annotation layer in the requested format. The default
+        JSON response carries layer metadata, the full taxonomy, and all
+        annotations with their target tokens (id + resolved surface text)
+        and body (key-value pairs from `@ana`, `@corresp`, and
+        `tei:note[@type]`).
+
+
+        Use `format=tei` to get the raw TEI document, or `format=tsv`
+        to get a tab-separated table with dynamically derived columns.
+
+
+        Use `category` to filter annotations by `@ana` value (single,
+        comma-separated, or repeated). The filter is ignored for
+        `format=tei`. `size` and `categoryCounts` reflect the filtered
+        set; `taxonomy` always contains the full taxonomy from the layer.
+      operationId: get-text-annotation-layer
+      tags: [annotations]
+      parameters:
+        - $ref: "#/components/parameters/corpusname"
+        - $ref: "#/components/parameters/textname"
+        - $ref: "#/components/parameters/layername"
+        - $ref: "#/components/parameters/format"
+        - $ref: "#/components/parameters/category"
+      responses:
+        '200':
+          description: >-
+            Returns the annotation layer as JSON (default), raw TEI XML
+            (format=tei), or TSV (format=tsv).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AnnotationLayerFull'
+            application/xml:
+              schema:
+                type: string
+            text/tab-separated-values:
+              schema:
+                type: string
+        '404':
+          description: Text or annotation layer not found
+
   /entities/{wikidataId}:
     get:
       summary: Get single entity
@@ -483,6 +528,54 @@ components:
       required: true
       schema:
         type: string
+    layername:
+      name: layername
+      in: path
+      required: true
+      description: >
+        Annotation layer name as provided in the `name` property of the
+        layers listing. This is the filename without `.xml`.
+      schema:
+        type: string
+      examples:
+        linguistic:
+          value: linguistic
+          summary: POS and lemma annotations
+        dictionarylookup:
+          value: dictionarylookup
+          summary: Entity annotations from dictionary lookup
+        ntee:
+          value: ntee
+          summary: Manual/expert entity annotations
+    format:
+      name: format
+      in: query
+      required: false
+      description: >
+        Output format. Default is "json". Use "tei" for the raw TEI
+        document or "tsv" for tab-separated values. The `category`
+        filter is ignored for `format=tei`.
+      schema:
+        type: string
+        enum: [json, tei, tsv]
+        default: json
+    category:
+      name: category
+      in: query
+      required: false
+      description: >
+        Filter annotations by category (the `@ana` value with leading
+        `#` stripped). Accepts a single value, a comma-separated list,
+        or a repeated query parameter.
+      schema:
+        type: string
+      examples:
+        plant:
+          value: cat-plant
+        animal:
+          value: cat-animal
+        noun:
+          value: stts-NN
   schemas:
     Info:
       type: object
@@ -755,3 +848,75 @@ components:
         - size
         - categoryCounts
         - uri
+    AnnotationLayerFull:
+      allOf:
+        - $ref: '#/components/schemas/AnnotationLayer'
+        - type: object
+          properties:
+            taxonomy:
+              type: object
+              description: >-
+                Category definitions from the layer's `<classDecl>`.
+                Always the full taxonomy, regardless of category filter.
+              properties:
+                id:
+                  type: string
+                categories:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      description:
+                        type: string
+            annotations:
+              type: array
+              items:
+                $ref: '#/components/schemas/Annotation'
+          required:
+            - annotations
+    Annotation:
+      type: object
+      properties:
+        target:
+          type: object
+          description: The annotated token(s)
+          properties:
+            id:
+              description: >-
+                Token xml:id. For multi-token spans this is an array of
+                ids in document order.
+              oneOf:
+                - type: string
+                - type: array
+                  items:
+                    type: string
+            text:
+              type: string
+              description: >-
+                Surface form of the target token(s), resolved from the
+                tokenized base TEI. Multi-token spans are joined with
+                single spaces.
+          required:
+            - id
+            - text
+        body:
+          type: array
+          description: >-
+            Key-value pairs representing the annotation content.
+            Keys come from TEI attributes (`ana`, `corresp`) and
+            `tei:note[@type]` children (e.g. `lemma`).
+          items:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+            required:
+              - key
+              - value
+      required:
+        - target
+        - body

--- a/api.yaml
+++ b/api.yaml
@@ -23,6 +23,8 @@ tags:
     description: Analyze a text.
   - name: entities
     description: Analyze occurrences of animals and plants in corpora and texts.
+  - name: annotations
+    description: Stand-off annotation layers on texts.
   - name: admin
     description: Manage corpora.
 
@@ -325,6 +327,33 @@ paths:
           description: Returns a plain text document
           content:
             text/plain:
+
+  /corpora/{corpusname}/texts/{textname}/annotations:
+    get:
+      summary: List stand-off annotation layers for a text
+      description: >-
+        Returns a list of annotation layers available for the text, with
+        metadata extracted from each layer's TEI header. The `name` field
+        comes from the filename (stable URL identifier); the `type` field
+        comes from `listAnnotation/@type` and describes the semantic kind
+        of annotations — multiple layers can share the same type (e.g.
+        `dictionarylookup` and `ntee` both have `type=entities`).
+      operationId: get-text-annotations
+      tags: [annotations]
+      parameters:
+        - $ref: "#/components/parameters/corpusname"
+        - $ref: "#/components/parameters/textname"
+      responses:
+        '200':
+          description: Returns an array of annotation layer objects
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AnnotationLayer'
+        '404':
+          description: Text not found or no annotations subcollection
 
   /entities/{wikidataId}:
     get:
@@ -678,3 +707,51 @@ components:
         uri:
           type: string
           format: url
+    AnnotationLayer:
+      type: object
+      properties:
+        name:
+          type: string
+          description: >-
+            Layer identifier (filename without .xml). Stable URL
+            identifier used in /annotations/{layername}.
+        type:
+          type: string
+          description: >-
+            Annotation type from listAnnotation/@type. Multiple layers
+            can have the same type (e.g. dictionarylookup and ntee both
+            have type=entities).
+        size:
+          type: integer
+          description: Number of annotation elements in the layer
+        categoryCounts:
+          type: object
+          description: >-
+            Per-category count (keys are @ana values with leading #
+            stripped, values are counts).
+          additionalProperties:
+            type: integer
+        uri:
+          type: string
+          format: url
+        title:
+          type: string
+        licence:
+          type: string
+          format: url
+        source:
+          type: string
+          description: Filename of the base TEI this layer annotates
+        application:
+          type: object
+          properties:
+            ident:
+              type: string
+            version:
+              type: string
+      required:
+        - name
+        - type
+        - size
+        - categoryCounts
+        - uri

--- a/api.yaml
+++ b/api.yaml
@@ -399,6 +399,64 @@ paths:
                 type: string
         '404':
           description: Text or annotation layer not found
+    put:
+      summary: Add or replace an annotation layer
+      description: >-
+        Stores the request body as `{layername}.xml` in the text's
+        annotations/ subcollection, creating the subcollection if
+        missing. Replaces on re-upload. Admin endpoint.
+
+
+        The layer name must consist of lowercase ASCII letters, digits
+        and dashes only. The request body must be a TEI document; no
+        further validation is performed.
+      operationId: put-text-annotation-layer
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/corpusname"
+        - $ref: "#/components/parameters/textname"
+        - $ref: "#/components/parameters/layername"
+      requestBody:
+        required: true
+        content:
+          application/xml:
+            schema:
+              type: string
+      responses:
+        '201':
+          description: Annotation layer stored (new)
+          content:
+            application/json:
+              schema:
+                type: object
+        '200':
+          description: Annotation layer replaced
+          content:
+            application/json:
+              schema:
+                type: object
+        '400':
+          description: Invalid layer name or missing TEI document
+        '401':
+          description: Authorization required
+        '404':
+          description: Text not found
+    delete:
+      summary: Delete an annotation layer
+      description: Admin endpoint.
+      operationId: delete-text-annotation-layer
+      tags: [admin]
+      parameters:
+        - $ref: "#/components/parameters/corpusname"
+        - $ref: "#/components/parameters/textname"
+        - $ref: "#/components/parameters/layername"
+      responses:
+        '200':
+          description: Layer deleted
+        '401':
+          description: Authorization required
+        '404':
+          description: Layer not found
 
   /entities/{wikidataId}:
     get:

--- a/data.xconf
+++ b/data.xconf
@@ -2,6 +2,11 @@
 <collection xmlns="http://exist-db.org/collection-config/1.0">
   <index xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tei="http://www.tei-c.org/ns/1.0">
     <lucene/>
+    <range>
+      <create qname="@xml:id" type="xs:string"/>
+      <create qname="@target" type="xs:string"/>
+      <create qname="@type" type="xs:string"/>
+    </range>
   </index>
   <triggers>
     <trigger class="org.exist.collections.triggers.XQueryTrigger">

--- a/modules/api.xqm
+++ b/modules/api.xqm
@@ -982,3 +982,112 @@ function api:text-annotation-layer(
           )
         )
 };
+
+(:~
+ : Add or replace an annotation layer for a text (admin endpoint)
+ :
+ : Stores the body as `{layerkey}.xml` in the text's annotations/
+ : subcollection. Creates the subcollection if missing. Accepts any
+ : TEI document without further validation.
+ :
+ : @param $corpusname Corpus name
+ : @param $textname Text name
+ : @param $layerkey Layer name (URL identifier, becomes filename)
+ : @param $data TEI document
+ : @param $auth Authorization header value
+ : @result JSON object with a confirmation message
+ :)
+declare
+  %rest:PUT("{$data}")
+  %rest:path("/ecocor/corpora/{$corpusname}/texts/{$textname}/annotations/{$layerkey}")
+  %rest:header-param("Authorization", "{$auth}")
+  %rest:consumes("application/xml", "text/xml")
+  %rest:produces("application/json")
+  %output:media-type("application/json")
+  %output:method("json")
+function api:text-annotation-layer-put(
+  $corpusname, $textname, $layerkey, $data, $auth
+) {
+  if (not($auth)) then
+    (
+      <rest:response><http:response status="401"/></rest:response>,
+      map { "message": "authorization required" }
+    )
+  else if (not(matches($layerkey, '^[a-z0-9]+(-[a-z0-9]+)*$'))) then
+    (
+      <rest:response><http:response status="400"/></rest:response>,
+      map {
+        "error": "invalid layer name",
+        "message": "Only lower case ASCII letters, digits and dashes are accepted."
+      }
+    )
+  else if (not($data/tei:TEI)) then
+    (
+      <rest:response><http:response status="400"/></rest:response>,
+      map { "error": "TEI document required" }
+    )
+  else
+    let $paths := ecutil:filepaths($corpusname, $textname)
+    let $text-collection := $paths?collections?text
+    return
+      if (not(xmldb:collection-available($text-collection))) then
+        (
+          <rest:response><http:response status="404"/></rest:response>,
+          map { "error": "no such text" }
+        )
+      else
+        let $ann-collection := xmldb:create-collection(
+          $text-collection, "annotations"
+        )
+        let $filename := $layerkey || ".xml"
+        let $existed := doc-available($ann-collection || "/" || $filename)
+        let $_ := xmldb:store($ann-collection, $filename, $data/tei:TEI)
+        return (
+          <rest:response>
+            <http:response status="{ if ($existed) then '200' else '201' }"/>
+          </rest:response>,
+          map {
+            "name": $layerkey,
+            "uri": $paths?uri || "/annotations/" || $layerkey,
+            "message": if ($existed) then "annotation layer replaced"
+                       else "annotation layer stored"
+          }
+        )
+};
+
+(:~
+ : Delete an annotation layer (admin endpoint)
+ :
+ : @param $corpusname Corpus name
+ : @param $textname Text name
+ : @param $layerkey Layer name
+ : @param $auth Authorization header value
+ : @result JSON object with a confirmation message
+ :)
+declare
+  %rest:DELETE
+  %rest:path("/ecocor/corpora/{$corpusname}/texts/{$textname}/annotations/{$layerkey}")
+  %rest:header-param("Authorization", "{$auth}")
+  %rest:produces("application/json")
+  %output:media-type("application/json")
+  %output:method("json")
+function api:text-annotation-layer-delete(
+  $corpusname, $textname, $layerkey, $auth
+) {
+  if (not($auth)) then
+    (
+      <rest:response><http:response status="401"/></rest:response>,
+      map { "message": "authorization required" }
+    )
+  else
+    let $paths := ecutil:filepaths($corpusname, $textname)
+    let $ann-collection := $paths?collections?text || "/annotations"
+    let $filename := $layerkey || ".xml"
+    let $file-uri := $ann-collection || "/" || $filename
+    return
+      if (not(doc-available($file-uri))) then
+        <rest:response><http:response status="404"/></rest:response>
+      else
+        let $_ := xmldb:remove($ann-collection, $filename)
+        return map { "message": "annotation layer deleted" }
+};

--- a/modules/api.xqm
+++ b/modules/api.xqm
@@ -808,3 +808,177 @@ function api:text-annotations($corpusname, $textname) {
         ))
       }
 };
+
+(:~
+ : Get a single annotation layer
+ :
+ : Returns JSON (default), TEI XML, or TSV depending on the format
+ : parameter. The layer is looked up by filename — the URL segment
+ : matches `{layername}.xml` in the text's annotations/ subcollection.
+ :
+ : Query params:
+ :   format   "json" (default) | "tei" | "tsv"
+ :   category filter annotations by @ana value (stripped of #).
+ :            Accepts single value, comma-separated, or repeated param.
+ :            Ignored when format=tei.
+ :
+ : @param $corpusname Corpus name
+ : @param $textname Text name
+ : @param $layername Layer name (filename without .xml)
+ : @param $format Output format
+ : @param $category Category filter(s)
+ :)
+declare
+  %rest:GET
+  %rest:path("/ecocor/corpora/{$corpusname}/texts/{$textname}/annotations/{$layername}")
+  %rest:query-param("format", "{$format}", "json")
+  %rest:query-param("category", "{$category}")
+function api:text-annotation-layer(
+  $corpusname, $textname, $layername, $format, $category
+) {
+  let $paths := ecutil:filepaths($corpusname, $textname)
+  let $ann-file := $paths?collections?text || "/annotations/" || $layername || ".xml"
+  let $doc := if (doc-available($ann-file)) then doc($ann-file) else ()
+
+  return
+    if (not($doc)) then
+      <rest:response>
+        <http:response status="404"/>
+      </rest:response>
+    else if ($format = "tei") then (
+      <rest:response>
+        <http:response status="200">
+          <http:header name="Content-Type" value="application/xml"/>
+        </http:response>
+      </rest:response>,
+      $doc/tei:TEI
+    )
+    else
+      (: Tokenized base TEI for surface-form resolution :)
+      let $tokenized-file := $paths?collections?text || "/tokenized.xml"
+      let $tokenized := if (doc-available($tokenized-file)) then doc($tokenized-file) else ()
+      let $token-map := map:merge(
+        for $t in $tokenized//tei:text//(tei:w|tei:pc)[@xml:id]
+        return map:entry(string($t/@xml:id), string($t))
+      )
+
+      (: Category filter: single value, comma-separated, or repeated :)
+      let $categories :=
+        for $c in $category
+        return tokenize($c, ',')
+      let $annotations :=
+        if (count($categories) > 0) then
+          $doc//tei:annotation[replace(@ana, '^#', '') = $categories]
+        else
+          $doc//tei:annotation
+
+      return if ($format = "tsv") then
+        let $all-keys := distinct-values((
+          for $a in $annotations return (
+            for $attr in $a/(@ana, @corresp) return local-name($attr),
+            for $note in $a/tei:note[@type] return string($note/@type)
+          )
+        ))
+        let $header := string-join(("target_id", "target_text", $all-keys), "&#9;")
+        let $rows :=
+          for $a in $annotations
+          let $targets := tokenize(string($a/@target), '\s+')
+          let $ids := for $t in $targets return replace($t, '^#', '')
+          let $texts := for $id in $ids return ($token-map($id), '')[1]
+          let $body-map := map:merge((
+            for $attr in $a/(@ana, @corresp)
+            return map:entry(local-name($attr), string($attr)),
+            for $note in $a/tei:note[@type]
+            return map:entry(string($note/@type), normalize-space($note))
+          ))
+          return string-join((
+            string-join($ids, ' '),
+            string-join($texts, ' '),
+            for $k in $all-keys return ($body-map($k), '')[1]
+          ), "&#9;")
+        return (
+          <rest:response>
+            <http:response status="200">
+              <http:header name="Content-Type" value="text/tab-separated-values; charset=utf-8"/>
+            </http:response>
+          </rest:response>,
+          string-join(($header, $rows), "&#10;")
+        )
+      else
+        let $header := $doc//tei:teiHeader
+        let $name := $layername
+        let $type := string($doc//tei:listAnnotation/@type)
+        let $title := $header//tei:titleStmt/tei:title[1]/string()
+        let $licence := $header//tei:availability/tei:licence/@target/string()
+        let $source := $header//tei:sourceDesc/tei:bibl/tei:ref[@type="source"]/@target/string()
+        let $app := $header//tei:appInfo/tei:application
+        let $taxonomy := $header//tei:classDecl/tei:taxonomy
+
+        return (
+          <rest:response>
+            <http:response status="200">
+              <http:header name="Content-Type" value="application/json"/>
+            </http:response>
+          </rest:response>,
+          serialize(
+            map:merge((
+              map {
+                "name": $name,
+                "type": $type,
+                "size": count($annotations),
+                "categoryCounts": map:merge(
+                  for $a in $annotations
+                  let $cat := replace(string($a/@ana), '^#', '')
+                  group by $cat
+                  return map:entry($cat, count($a))
+                )
+              },
+              if ($title) then map:entry("title", $title) else (),
+              if ($licence) then map:entry("licence", $licence) else (),
+              if ($source) then map:entry("source", $source) else (),
+              if ($app) then map:entry("application", map {
+                "ident": $app/@ident/string(),
+                "version": $app/@version/string()
+              }) else (),
+              if ($taxonomy) then map:entry("taxonomy", map {
+                "id": $taxonomy/@xml:id/string(),
+                "categories": array {
+                  for $cat in $taxonomy/tei:category
+                  return map {
+                    "id": $cat/@xml:id/string(),
+                    "description": normalize-space($cat/tei:catDesc)
+                  }
+                }
+              }) else (),
+              map:entry("annotations", array {
+                for $a in $annotations
+                let $targets := tokenize(string($a/@target), '\s+')
+                let $ids := for $t in $targets return replace($t, '^#', '')
+                let $texts := for $id in $ids return ($token-map($id), '')[1]
+                return map {
+                  "target": if (count($ids) = 1) then
+                    map { "id": $ids[1], "text": $texts[1] }
+                  else
+                    map {
+                      "id": array { $ids },
+                      "text": string-join($texts, ' ')
+                    },
+                  "body": array {
+                    for $attr in $a/(@ana, @corresp)
+                    return map {
+                      "key": local-name($attr),
+                      "value": string($attr)
+                    },
+                    for $note in $a/tei:note[@type]
+                    return map {
+                      "key": string($note/@type),
+                      "value": normalize-space($note)
+                    }
+                  }
+                }
+              })
+            )),
+            map { "method": "json" }
+          )
+        )
+};

--- a/modules/api.xqm
+++ b/modules/api.xqm
@@ -740,3 +740,71 @@ function api:text-plain($corpusname, $textname) {
         <http:response status="404"/>
       </rest:response>
 };
+
+(:~
+ : List stand-off annotation layers for a text
+ :
+ : Returns an array of layer metadata objects. The layer name comes from
+ : the filename in the text's annotations/ subcollection (not from
+ : listAnnotation/@type, which is exposed separately as "type").
+ :
+ : @param $corpusname Corpus name
+ : @param $textname Text name
+ : @result JSON array of annotation layer objects
+ :)
+declare
+  %rest:GET
+  %rest:path("/ecocor/corpora/{$corpusname}/texts/{$textname}/annotations")
+  %rest:produces("application/json")
+  %output:media-type("application/json")
+  %output:method("json")
+function api:text-annotations($corpusname, $textname) {
+  let $paths := ecutil:filepaths($corpusname, $textname)
+  let $text-collection := $paths?collections?text
+  let $ann-collection := $text-collection || "/annotations"
+
+  return
+    if (not(xmldb:collection-available($text-collection))) then
+      <rest:response>
+        <http:response status="404"/>
+      </rest:response>
+    else if (not(xmldb:collection-available($ann-collection))) then
+      <rest:response>
+        <http:response status="404"/>
+      </rest:response>
+    else
+      array {
+        for $resource in xmldb:get-child-resources($ann-collection)
+        let $doc := doc($ann-collection || "/" || $resource)
+        let $name := replace($resource, '\.xml$', '')
+        let $header := $doc//tei:teiHeader
+        let $type := string($doc//tei:listAnnotation/@type)
+        let $title := $header//tei:titleStmt/tei:title[1]/string()
+        let $licence := $header//tei:availability/tei:licence/@target/string()
+        let $source := $header//tei:sourceDesc/tei:bibl/tei:ref[@type="source"]/@target/string()
+        let $app := $header//tei:appInfo/tei:application
+        let $annotations := $doc//tei:annotation
+        order by $name
+        return map:merge((
+          map {
+            "name": $name,
+            "type": $type,
+            "size": count($annotations),
+            "categoryCounts": map:merge(
+              for $a in $annotations
+              let $cat := replace(string($a/@ana), '^#', '')
+              group by $cat
+              return map:entry($cat, count($a))
+            ),
+            "uri": $paths?uri || "/annotations/" || $name
+          },
+          if ($title) then map:entry("title", $title) else (),
+          if ($licence) then map:entry("licence", $licence) else (),
+          if ($source) then map:entry("source", $source) else (),
+          if ($app) then map:entry("application", map {
+            "ident": $app/@ident/string(),
+            "version": $app/@version/string()
+          }) else ()
+        ))
+      }
+};

--- a/scripts/sideload-annotations.sh
+++ b/scripts/sideload-annotations.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Sideload tokenized TEI files and annotation layers from a local corpus
+# repo into a running eXist-db. Assumes the base corpus (tei.xml per text)
+# has already been loaded via the normal POST /corpora/{name} flow.
+#
+# For each text collection {text}/ the script adds:
+#   tokenized.xml                        (from repo's tokenized/)
+#   annotations/{layer}.xml              (from repo's annotations/{layer}/)
+#
+# Creates the annotations subcollection via an XQuery call if needed.
+#
+# Usage:
+#   sideload-annotations.sh <repo-path> <corpus-name>
+#
+# Example:
+#   sideload-annotations.sh ../eco-de de
+
+set -eu
+
+REPO="${1:-}"
+CORPUS="${2:-}"
+EXIST="${EXIST_URL:-http://localhost:8090/exist}"
+AUTH="${EXIST_AUTH:-admin:}"
+
+if [[ -z "$REPO" || -z "$CORPUS" ]]; then
+  echo "usage: $0 <repo-path> <corpus-name>" >&2
+  exit 1
+fi
+
+if [[ ! -d "$REPO/tokenized" ]]; then
+  echo "error: $REPO/tokenized not found" >&2
+  exit 1
+fi
+
+CORPORA="/db/ecocor/corpora"
+BASE="$EXIST/rest$CORPORA/$CORPUS"
+
+# Map eco_de_000033 filename → eXist text collection name (lowercased).
+# Example: 1807_Kleist_Erdbeben.xml → 1807_kleist_erdbeben
+text_collection() {
+  local filename="$1"
+  local stem="${filename%.xml}"
+  echo "$stem" | tr '[:upper:]' '[:lower:]'
+}
+
+put() {
+  local path="$1" file="$2"
+  local code
+  code=$(curl -s -o /dev/null -w "%{http_code}" -X PUT \
+    -H "Content-Type: application/xml" \
+    --data-binary "@$file" \
+    -u "$AUTH" \
+    "$BASE/$path")
+  if [[ "$code" != "200" && "$code" != "201" ]]; then
+    echo "  FAIL $path (HTTP $code)" >&2
+    return 1
+  fi
+}
+
+mkcol() {
+  # Create a collection via XQuery. eXist REST doesn't do MKCOL.
+  local parent="$1" name="$2"
+  curl -s -u "$AUTH" \
+    --data-urlencode "_query=xmldb:create-collection('$parent', '$name')" \
+    "$EXIST/rest/db/" > /dev/null
+}
+
+# --- tokenized ---
+echo "Uploading tokenized/"
+count=0
+for f in "$REPO"/tokenized/*.xml; do
+  [[ -f "$f" ]] || continue
+  filename=$(basename "$f")
+  text=$(text_collection "$filename")
+  put "$text/tokenized.xml" "$f"
+  count=$((count + 1))
+done
+echo "  $count files"
+
+# --- annotation layers ---
+if [[ -d "$REPO/annotations" ]]; then
+  for layer_dir in "$REPO"/annotations/*/; do
+    [[ -d "$layer_dir" ]] || continue
+    layer=$(basename "$layer_dir")
+    echo "Uploading annotations/$layer/"
+    count=0
+    for f in "$layer_dir"*.xml; do
+      [[ -f "$f" ]] || continue
+      filename=$(basename "$f")
+      text=$(text_collection "$filename")
+      mkcol "$CORPORA/$CORPUS/$text" "annotations"
+      put "$text/annotations/$layer.xml" "$f"
+      count=$((count + 1))
+    done
+    echo "  $count files"
+  done
+fi
+
+echo "Done."


### PR DESCRIPTION
# Add annotations

## Summary

Adds new endpoints for managing and querying stand-off annotation layers on tokenized TEI texts. The legacy `/entities` and extractor microservice are untouched.

## New endpoints

| Method | Path | Purpose |
|--------|------|---------|
| GET | `/corpora/{c}/texts/{t}/annotations` | List annotation layers for a text |
| GET | `/corpora/{c}/texts/{t}/annotations/{layer}` | Get a single layer (JSON/TEI/TSV) |
| PUT | `/corpora/{c}/texts/{t}/annotations/{layer}` | Upload/replace a layer (admin) |
| DELETE | `/corpora/{c}/texts/{t}/annotations/{layer}` | Delete a layer (admin) |

## Behaviour

- **Layer identifier (`name`)** = filename without `.xml`. Stable URL identifier. Layers are looked up by filename, *not* by `listAnnotation/@type` — multiple layers can share the same type (e.g. `dictionarylookup` and `ntee` both have `type="entities"`).
- **`type`** (from `listAnnotation/@type`) is exposed as a separate field, alongside `name`.
- **`format` query param** on GET layer: `json` (default), `tei`, `tsv`. TSV columns are derived dynamically from body keys.
- **`category` query param** on GET layer: filter by `@ana` value. Single, comma-separated, or repeated param. `size` and `categoryCounts` reflect the filtered set; `taxonomy` always contains the full set. Filter is ignored for `format=tei`.
- **Response metadata** extracted from `teiHeader`: `title`, `licence`, `source`, `application`.

## Storage layout

Annotation layers live in per-text subcollections alongside the existing files:

```
/db/ecocor/corpora/{corpus}/{text}/
  tei.xml            ← base TEI (raw, from repo)
  tokenized.xml      ← vanilla tokenized TEI with <w>/<pc> — NEW
  metrics.xml
  entities.xml
  git.xml
  annotations/       ← NEW subcollection
    linguistic.xml
    dictionarylookup.xml
    ntee.xml
```

The new `tokenized.xml` is used to resolve surface forms for annotation targets (ids in `@target` → text content of matching `<w>` / `<pc>`).

## Other changes

- `data.xconf`: added range indexes on `@xml:id`, `@target`, `@type`. Without these, resolving surface forms for large layers (e.g. Goethe *Lehrjahre* ~194k linguistic annotations) times out.
- `scripts/sideload-annotations.sh`: loads `tokenized/` and `annotations/{layer}/` from a local repo into a running eXist-db. Used during development to populate the Kleist + full German corpus for testing. Assumes the base corpus has already been loaded via the normal `POST /corpora/{name}` flow.

## Performance

Surface-form resolution uses a pre-built `map:merge` token lookup from `tokenized.xml` (O(1) per annotation), combined with the new range indexes.

Measured on the live dev instance:
- Kleist linguistic layer (5,391 annotations) — ~0.4s
- Goethe *Lehrjahre* linguistic layer (~194k annotations) — ~7s, 26 MB response

## Not included

- No validation of uploaded annotation files beyond "must be a `<TEI>` document". Layer-specific validation (e.g. taxonomy conformance, `@target` resolution) can be added later.
- No changes to the loading pipeline. Annotation layers are loaded via the sideload script or the new PUT endpoint; automated ingest from corpus repos is a separate concern.

## Test plan

- [ ] `GET /annotations` lists all layers for a text with metadata and category counts
- [ ] `GET /annotations/{layer}` returns full layer as JSON with target/body structure and taxonomy
- [ ] `GET /annotations/{layer}?format=tei` returns raw TEI XML
- [ ] `GET /annotations/{layer}?format=tsv` returns tab-separated export
- [ ] `GET /annotations/{layer}?category=X` filters annotations; `categoryCounts` reflects filter
- [ ] `PUT /annotations/{layer}` with auth creates the layer (201) or replaces it (200)
- [ ] `PUT /annotations/{layer}` without auth returns 401; invalid layer name returns 400
- [ ] `DELETE /annotations/{layer}` with auth removes the layer
