### PR TITLE
Tokens endpoint

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -23,6 +23,8 @@ tags:
     description: Analyze a text.
   - name: entities
     description: Analyze occurrences of animals and plants in corpora and texts.
+  - name: tokens
+    description: Word and punctuation tokens from the tokenized TEI.
   - name: admin
     description: Manage corpora.
 
@@ -326,6 +328,59 @@ paths:
           content:
             text/plain:
 
+  /corpora/{corpusname}/texts/{textname}/tokens:
+    get:
+      summary: List all tokens of a text
+      description: >-
+        Returns all `<w>` and `<pc>` tokens from the tokenized base TEI
+        (`tokenized.xml`) in document order. The `unit` field is only
+        present on punctuation tokens that carry `@unit` (e.g. "sentence").
+      operationId: get-text-tokens
+      tags: [tokens]
+      parameters:
+        - $ref: "#/components/parameters/corpusname"
+        - $ref: "#/components/parameters/textname"
+        - $ref: "#/components/parameters/format"
+      responses:
+        '200':
+          description: Returns token list as JSON (default) or TSV
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Token'
+            text/tab-separated-values:
+              schema:
+                type: string
+        '404':
+          description: Tokenized TEI not found
+
+  /corpora/{corpusname}/texts/{textname}/tokens/{tokenid}:
+    get:
+      summary: Get a single token with all annotations
+      description: >-
+        Looks up the token in `tokenized.xml` by xml:id and aggregates
+        all annotations that target it across every layer in the
+        text's annotations/ subcollection. The `annotations` array is
+        flat; each entry carries its `layer` name and a `body` of
+        key-value pairs.
+      operationId: get-text-token
+      tags: [tokens]
+      parameters:
+        - $ref: "#/components/parameters/corpusname"
+        - $ref: "#/components/parameters/textname"
+        - $ref: "#/components/parameters/tokenid"
+      responses:
+        '200':
+          description: Returns the token with its annotations
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenWithAnnotations'
+        '404':
+          description: Token not found
+
   /entities/{wikidataId}:
     get:
       summary: Get single entity
@@ -454,6 +509,29 @@ components:
       required: true
       schema:
         type: string
+    tokenid:
+      name: tokenid
+      in: path
+      required: true
+      description: >
+        Token xml:id as found in the tokenized base TEI.
+      schema:
+        type: string
+      examples:
+        pinien:
+          value: eco_de_000033_140_0730
+          summary: "Pinien (Kleist: Das Erdbeben in Chili)"
+    format:
+      name: format
+      in: query
+      required: false
+      description: >
+        Output format. Default is "json". Use "tsv" for a
+        tab-separated table.
+      schema:
+        type: string
+        enum: [json, tsv]
+        default: json
   schemas:
     Info:
       type: object
@@ -678,3 +756,54 @@ components:
         uri:
           type: string
           format: url
+    Token:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Token xml:id
+        text:
+          type: string
+          description: Surface form
+        type:
+          type: string
+          enum: [w, pc]
+          description: Element type (word or punctuation)
+        unit:
+          type: string
+          description: Punctuation unit (e.g. "sentence"), only on pc tokens
+      required:
+        - id
+        - text
+        - type
+    TokenWithAnnotations:
+      allOf:
+        - $ref: '#/components/schemas/Token'
+        - type: object
+          properties:
+            annotations:
+              type: array
+              description: >-
+                Annotations from all layers targeting this token. Each
+                entry carries the layer name and a body of key-value
+                pairs (from @ana, @corresp, and note[@type]).
+              items:
+                type: object
+                properties:
+                  layer:
+                    type: string
+                  body:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          type: string
+                        value:
+                          type: string
+                      required:
+                        - key
+                        - value
+                required:
+                  - layer
+                  - body

--- a/data.xconf
+++ b/data.xconf
@@ -2,6 +2,11 @@
 <collection xmlns="http://exist-db.org/collection-config/1.0">
   <index xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tei="http://www.tei-c.org/ns/1.0">
     <lucene/>
+    <range>
+      <create qname="@xml:id" type="xs:string"/>
+      <create qname="@target" type="xs:string"/>
+      <create qname="@type" type="xs:string"/>
+    </range>
   </index>
   <triggers>
     <trigger class="org.exist.collections.triggers.XQueryTrigger">

--- a/modules/api.xqm
+++ b/modules/api.xqm
@@ -740,3 +740,154 @@ function api:text-plain($corpusname, $textname) {
         <http:response status="404"/>
       </rest:response>
 };
+
+(:~
+ : List all tokens (<w> and <pc>) of a text
+ :
+ : Source: {text}/tokenized.xml. Returns 404 if that document is missing.
+ :
+ : @param $corpusname Corpus name
+ : @param $textname Text name
+ : @param $format Output format: "json" (default) or "tsv"
+ :)
+declare
+  %rest:GET
+  %rest:path("/ecocor/corpora/{$corpusname}/texts/{$textname}/tokens")
+  %rest:query-param("format", "{$format}", "json")
+function api:text-tokens($corpusname, $textname, $format) {
+  let $paths := ecutil:filepaths($corpusname, $textname)
+  let $tokenized-file := $paths?collections?text || "/tokenized.xml"
+  let $tokenized := if (doc-available($tokenized-file)) then doc($tokenized-file) else ()
+
+  return
+    if (not($tokenized)) then (
+      <rest:response><http:response status="404"/></rest:response>,
+      map {
+        "error": "tokenized TEI not found",
+        "message": "No tokenized.xml for text '" || $textname
+          || "' in corpus '" || $corpusname
+          || "'. This endpoint requires a tokenized TEI (with <w>/<pc> elements) alongside the base tei.xml."
+      }
+    )
+    else
+      let $tokens := $tokenized//tei:text//(tei:w|tei:pc)
+      return if ($format = "tsv") then
+        let $header := string-join(("id", "text", "type"), "&#9;")
+        let $rows :=
+          for $token in $tokens
+          return string-join((
+            string($token/@xml:id),
+            string($token),
+            local-name($token)
+          ), "&#9;")
+        return (
+          <rest:response>
+            <http:response status="200">
+              <http:header name="Content-Type" value="text/tab-separated-values; charset=utf-8"/>
+            </http:response>
+          </rest:response>,
+          string-join(($header, $rows), "&#10;")
+        )
+      else (
+        <rest:response>
+          <http:response status="200">
+            <http:header name="Content-Type" value="application/json"/>
+          </http:response>
+        </rest:response>,
+        serialize(
+          array {
+            for $token in $tokens
+            return map:merge((
+              map {
+                "id": string($token/@xml:id),
+                "text": string($token),
+                "type": local-name($token)
+              },
+              if ($token/@unit) then map:entry("unit", string($token/@unit)) else ()
+            ))
+          },
+          map { "method": "json" }
+        )
+      )
+};
+
+(:~
+ : Get a single token with all annotations
+ :
+ : Looks up the token in tokenized.xml by xml:id and aggregates all
+ : annotations targeting it across every layer in annotations/. The
+ : annotations array is flat; each entry carries its layer name.
+ :
+ : @param $corpusname Corpus name
+ : @param $textname Text name
+ : @param $tokenid Token xml:id
+ :)
+declare
+  %rest:GET
+  %rest:path("/ecocor/corpora/{$corpusname}/texts/{$textname}/tokens/{$tokenid}")
+  %rest:produces("application/json")
+  %output:media-type("application/json")
+  %output:method("json")
+function api:text-token($corpusname, $textname, $tokenid) {
+  let $paths := ecutil:filepaths($corpusname, $textname)
+  let $tokenized-file := $paths?collections?text || "/tokenized.xml"
+  let $tokenized := if (doc-available($tokenized-file)) then doc($tokenized-file) else ()
+  let $token :=
+    if ($tokenized) then
+      $tokenized//(tei:w|tei:pc)[@xml:id = $tokenid]
+    else ()
+
+  return
+    if (not($tokenized)) then (
+      <rest:response><http:response status="404"/></rest:response>,
+      map {
+        "error": "tokenized TEI not found",
+        "message": "No tokenized.xml for text '" || $textname
+          || "' in corpus '" || $corpusname || "'."
+      }
+    )
+    else if (not($token)) then (
+      <rest:response><http:response status="404"/></rest:response>,
+      map {
+        "error": "token not found",
+        "message": "No <w> or <pc> element with xml:id='" || $tokenid
+          || "' in text '" || $textname || "'."
+      }
+    )
+    else
+      let $ann-collection := $paths?collections?text || "/annotations"
+      let $target-ref := "#" || $tokenid
+      return map:merge((
+        map {
+          "id": $tokenid,
+          "text": string($token),
+          "type": local-name($token)
+        },
+        if ($token/@unit) then map:entry("unit", string($token/@unit)) else (),
+        if (xmldb:collection-available($ann-collection)) then
+          map:entry("annotations", array {
+            for $resource in xmldb:get-child-resources($ann-collection)
+            let $doc := doc($ann-collection || "/" || $resource)
+            let $layername := replace($resource, '\.xml$', '')
+            for $a in $doc//tei:annotation[
+              tokenize(@target, '\s+') = $target-ref
+            ]
+            return map {
+              "layer": $layername,
+              "body": array {
+                for $attr in $a/(@ana, @corresp)
+                return map {
+                  "key": local-name($attr),
+                  "value": string($attr)
+                },
+                for $note in $a/tei:note[@type]
+                return map {
+                  "key": string($note/@type),
+                  "value": normalize-space($note)
+                }
+              }
+            }
+          })
+        else ()
+      ))
+};


### PR DESCRIPTION
# Add tokens API

## Summary

Adds endpoints for querying tokens of a tokenized TEI text, and for looking up a single token with all annotations aggregated across every annotation layer.

Branched from `main` (the `annotations-endpoint` PR can merge in either order). Shares the `data.xconf` range-index change with that PR — if `annotations-endpoint` merges first, the cherry-picked commit here becomes a no-op.

## New endpoints

| Method | Path | Purpose |
|--------|------|---------|
| GET | `/corpora/{c}/texts/{t}/tokens` | List all `<w>` and `<pc>` tokens |
| GET | `/corpora/{c}/texts/{t}/tokens/{tokenid}` | Single token with aggregated annotations |

## Behaviour

### Token listing

- Source: `{text}/tokenized.xml` (vanilla tokenized TEI with `<w>`/`<pc>` and stable `xml:id`s).
- `?format=json` (default) — array of `{id, text, type}` objects (`type` is `"w"` or `"pc"`; `unit` added for `<pc>` with `@unit`, e.g. sentence boundaries).
- `?format=tsv` — tab-separated with header row.
- 404 with a verbose message when `tokenized.xml` is missing.

### Single token

- Looks up the token by `xml:id` in `tokenized.xml`.
- Iterates every file in `{text}/annotations/` and collects annotations whose `@target` references the token.
- Response: `{id, text, type, unit?, annotations}` where `annotations` is a flat array across layers. Each entry: `{layer, body}` with `body` being key-value pairs from `@ana`, `@corresp`, and `tei:note[@type]`.
- 404 with a verbose message when either the token id or `tokenized.xml` is missing.

## Dependencies

- `data.xconf`: range indexes on `@xml:id`, `@target`, `@type` (cherry-picked from `annotations-endpoint`). Without the `@target` index, the single-token endpoint scans every `<annotation>` element in every layer file — manageable but slow on texts with six-figure linguistic layers.

## Example responses

### `GET /corpora/de/texts/1807_kleist_erdbeben/tokens` (JSON, first 3)

```json
[
  { "id": "eco_de_000033_30_0010", "text": "In", "type": "w" },
  { "id": "eco_de_000033_30_0020", "text": "St.", "type": "w" },
  { "id": "eco_de_000033_30_0030", "text": "Jago", "type": "w" }
]
```

### `GET /corpora/de/texts/1807_kleist_erdbeben/tokens/eco_de_000033_140_0730`

```json
{
  "id": "eco_de_000033_140_0730",
  "text": "Pinien",
  "type": "w",
  "annotations": [
    {
      "layer": "dictionarylookup",
      "body": [
        { "key": "ana", "value": "#cat-plant" },
        { "key": "corresp", "value": "https://www.wikidata.org/wiki/Q106094" }
      ]
    },
    {
      "layer": "linguistic",
      "body": [
        { "key": "ana", "value": "#stts-NN" },
        { "key": "lemma", "value": "Pinie" }
      ]
    }
  ]
}
```

## Test plan

- [ ] `GET /tokens` returns full token list in document order (Kleist = 6,496 tokens)
- [ ] `GET /tokens?format=tsv` returns header + rows
- [ ] `GET /tokens/{tokenid}` returns token with aggregated annotations from every layer
- [ ] `GET /tokens/{nonexistent}` returns 404 with verbose error message
- [ ] Request on a text without `tokenized.xml` returns 404 with verbose error message
