### PR TITLE
Add Search endpoint

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -23,6 +23,8 @@ tags:
     description: Analyze a text.
   - name: entities
     description: Analyze occurrences of animals and plants in corpora and texts.
+  - name: search
+    description: Full-text search over corpora and texts.
   - name: admin
     description: Manage corpora.
 
@@ -325,6 +327,82 @@ paths:
           description: Returns a plain text document
           content:
             text/plain:
+
+  /search:
+    get:
+      summary: Full-text search across corpora and texts
+      description: >-
+        Paragraph-level Lucene full-text search over the tokenized TEI
+        of every text. Returns hits with KWIC context and URLs into
+        the DTS Collection, Navigation and Document endpoints. The
+        query syntax is Lucene's standard query parser — supports
+        phrases, boolean operators, wildcards, proximity etc.
+
+
+        Optionally restrict to a single corpus with `corpus=<name>` or
+        to a single text with `id=<resource-id>` (the DTS resource id,
+        matching `TEI/@xml:id` with the `_tokenized` suffix stripped).
+      operationId: get-search
+      tags: [search]
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Search query (Lucene syntax)
+          schema:
+            type: string
+          examples:
+            nachtigall:
+              value: Nachtigall
+            phrase:
+              value: '"im Wipfel"'
+            boolean:
+              value: "Nachtigall OR Lerche"
+        - name: corpus
+          in: query
+          required: false
+          description: Restrict search to a single corpus
+          schema:
+            type: string
+          examples:
+            german:
+              value: de
+        - name: id
+          in: query
+          required: false
+          description: >-
+            Restrict search to a single resource. The public DTS
+            resource id (not the internal `_tokenized` form).
+          schema:
+            type: string
+          examples:
+            kleist:
+              value: eco_de_000033
+        - name: limit
+          in: query
+          required: false
+          description: Number of results per page
+          schema:
+            type: integer
+            default: 20
+        - name: offset
+          in: query
+          required: false
+          description: Zero-based offset
+          schema:
+            type: integer
+            default: 0
+      responses:
+        '200':
+          description: Search result page
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchResults'
+        '400':
+          description: Parameter `q` missing
+        '404':
+          description: Corpus or resource not found
 
   /entities/{wikidataId}:
     get:
@@ -678,3 +756,72 @@ components:
         uri:
           type: string
           format: url
+    SearchResults:
+      type: object
+      properties:
+        query:
+          type: string
+        totalHits:
+          type: integer
+        offset:
+          type: integer
+        limit:
+          type: integer
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/SearchHit'
+      required:
+        - query
+        - totalHits
+        - offset
+        - limit
+        - results
+    SearchHit:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Resource id (DTS public form)
+        name:
+          type: string
+          description: Text slug (e.g. 1807_kleist_erdbeben)
+        corpus:
+          type: string
+        title:
+          type: string
+        authors:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+        citableUnit:
+          type: string
+          description: >-
+            Paragraph xml:id — usable as `ref` in DTS Navigation and
+            Document endpoints.
+        kwic:
+          type: string
+          description: Keyword-in-context snippet
+        collection:
+          type: string
+          format: url
+          description: DTS Collection URL for the resource
+        navigation:
+          type: string
+          format: url
+          description: DTS Navigation URL for the matching citable unit
+        document:
+          type: string
+          format: url
+          description: DTS Document URL for the matching citable unit
+      required:
+        - id
+        - name
+        - corpus
+        - title
+        - citableUnit
+        - kwic
+        - document

--- a/data.xconf
+++ b/data.xconf
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <collection xmlns="http://exist-db.org/collection-config/1.0">
   <index xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tei="http://www.tei-c.org/ns/1.0">
-    <lucene/>
+    <lucene>
+      <text qname="tei:p"/>
+    </lucene>
   </index>
   <triggers>
     <trigger class="org.exist.collections.triggers.XQueryTrigger">

--- a/modules/search.xqm
+++ b/modules/search.xqm
@@ -1,0 +1,145 @@
+xquery version "3.1";
+
+(:~
+ : Full-text search for the EcoCor API.
+ :
+ : Searches the tokenized TEI (`tokenized.xml`) of every text with
+ : Lucene's default analyzer, returning paragraph-level hits with KWIC
+ : context and links into the DTS Collection / Navigation / Document
+ : endpoints.
+ :
+ : Adapted from the ELTeC search module
+ : (https://github.com/clscor-io/eltec-api/blob/main/modules/search.xqm).
+ :)
+module namespace search = "http://ecocor.org/ns/exist/search";
+
+import module namespace config = "http://ecocor.org/ns/exist/config"
+  at "config.xqm";
+import module namespace ectei = "http://ecocor.org/ns/exist/tei"
+  at "tei.xqm";
+import module namespace ecutil = "http://ecocor.org/ns/exist/util"
+  at "util.xqm";
+import module namespace kwic = "http://exist-db.org/xquery/kwic";
+
+declare namespace rest = "http://exquery.org/ns/restxq";
+declare namespace http = "http://expath.org/ns/http-client";
+declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
+declare namespace tei = "http://www.tei-c.org/ns/1.0";
+
+(:~
+ : Public resource id — the tokenized TEI's xml:id with the
+ : `_tokenized` suffix stripped. Matches the DTS Resource id convention.
+ :)
+declare function search:resource-id(
+  $tei as element(tei:TEI)
+) as xs:string {
+  replace(string($tei/@xml:id), '_tokenized$', '')
+};
+
+(:~
+ : Full-text search across the EcoCor corpora.
+ :
+ : @param $q Search query (required, Lucene syntax)
+ : @param $corpus Optional corpus name to restrict search
+ : @param $id Optional resource id (public form, no _tokenized suffix)
+ : @param $limit Results per page (default 20)
+ : @param $offset Zero-based offset (default 0)
+ :)
+declare
+  %rest:GET
+  %rest:path("/ecocor/search")
+  %rest:query-param("q", "{$q}")
+  %rest:query-param("corpus", "{$corpus}")
+  %rest:query-param("id", "{$id}")
+  %rest:query-param("limit", "{$limit}")
+  %rest:query-param("offset", "{$offset}")
+  %rest:produces("application/json")
+  %output:media-type("application/json")
+  %output:method("json")
+function search:search(
+  $q as xs:string*,
+  $corpus as xs:string*,
+  $id as xs:string*,
+  $limit as xs:string*,
+  $offset as xs:string*
+) as item()+ {
+  if (not($q) or $q = "") then
+    (
+      <rest:response><http:response status="400"/></rest:response>,
+      map { "error": "Bad Request", "message": "Parameter 'q' is required." }
+    )
+  else
+
+  let $lim := if ($limit) then xs:integer($limit) else 20
+  let $off := if ($offset) then xs:integer($offset) else 0
+
+  let $collection-path :=
+    if ($corpus and $corpus != "")
+    then $config:corpora-root || "/" || $corpus
+    else $config:corpora-root
+
+  return
+    if ($corpus and not(xmldb:collection-available($collection-path))) then
+      (
+        <rest:response><http:response status="404"/></rest:response>,
+        map {
+          "error": "Not Found",
+          "message": "Corpus '" || $corpus || "' does not exist."
+        }
+      )
+    (: restrict to tokenized TEIs; match resource id via _tokenized suffix :)
+    else
+      let $scope := collection($collection-path)//tei:TEI[@type = "tokenized"]
+      let $scope := if ($id)
+        then $scope[@xml:id = $id || "_tokenized"]
+        else $scope
+      return
+        if ($id and empty($scope)) then
+          (
+            <rest:response><http:response status="404"/></rest:response>,
+            map {
+              "error": "Not Found",
+              "message": "Text '" || $id || "' does not exist."
+            }
+          )
+        else
+          let $hits := $scope//tei:p[ft:query(., $q)]
+          let $total := count($hits)
+          let $page := subsequence($hits, $off + 1, $lim)
+          let $dts-base := $config:api-base || "/dts"
+
+          let $results := array {
+            for $hit in $page
+            let $tei := $hit/ancestor::tei:TEI
+            let $resource-id := search:resource-id($tei)
+            let $titles := ectei:get-titles($tei)
+            let $authors := ectei:get-authors($tei)
+            let $paths := ecutil:filepaths(base-uri($tei))
+            let $cite-ref := string($hit/@xml:id)
+            let $summary := kwic:summarize($hit, <config width="40"/>)
+            return map {
+              "id": $resource-id,
+              "name": $paths?textname,
+              "corpus": $paths?corpusname,
+              "title": $titles?main,
+              "authors": array {
+                for $a in $authors return map { "name": $a?name }
+              },
+              "citableUnit": $cite-ref,
+              "kwic": normalize-space(string-join($summary//text(), " ")),
+              "collection": $dts-base || "/collection?id=" || $resource-id,
+              "navigation": $dts-base || "/navigation?resource=" || $resource-id
+                || "&amp;ref=" || $cite-ref,
+              "document": $dts-base || "/document?resource=" || $resource-id
+                || "&amp;ref=" || $cite-ref
+            }
+          }
+
+          return map {
+            "query": $q,
+            "totalHits": $total,
+            "offset": $off,
+            "limit": $lim,
+            "results": $results
+          }
+};


### PR DESCRIPTION
# Add full-text search endpoint

## Summary

Adds a paragraph-level Lucene full-text search endpoint at `/ecocor/search`. Adapted from the [ELTeC search module](https://github.com/clscor-io/eltec-api/blob/main/modules/search.xqm).

Branched from `main`. The response URLs point at the DTS endpoints (resource, navigation, document) — those live on the `dts` branch and will resolve once both PRs are merged. The search endpoint itself works standalone.

## New endpoint

| Method | Path | Purpose |
|--------|------|---------|
| GET | `/ecocor/search` | Paragraph-level full-text search |

## Query parameters

| Name | Required | Default | Notes |
|------|----------|---------|-------|
| `q` | yes | — | Lucene query string (phrases, booleans, wildcards, proximity…) |
| `corpus` | no | all | Restrict to one corpus |
| `id` | no | all | Restrict to one resource (DTS public id, no `_tokenized` suffix) |
| `limit` | no | 20 | Results per page |
| `offset` | no | 0 | Zero-based offset |

## Data source

Searches the **tokenized TEI** (`{text}/tokenized.xml`, `TEI/@type="tokenized"`), not the raw `tei.xml`. Rationale: keeps the citable-unit ids consistent with the DTS Navigation/Document endpoints, and makes future lemma- or entity-aware search trivial because the same document is the join point for the annotation layers.

Lucene's default analyzer flattens `<p>` text across `<w>`/`<pc>` children, so full-text search works normally. KWIC extraction is handled by `kwic:summarize` with whitespace normalization across token children.

## Response shape

```json
{
  "query": "Nachtigall",
  "totalHits": 132,
  "offset": 0,
  "limit": 20,
  "results": [
    {
      "id": "eco_de_000033",
      "name": "1807_kleist_erdbeben",
      "corpus": "de",
      "title": "Das Erdbeben in Chili",
      "authors": [{ "name": "von Kleist, Wilhelm" }],
      "citableUnit": "eco_de_000033_150",
      "kwic": "...weit ausbreitete ; und die Nachtigall flötete im Wipfel ihr woll...",
      "collection": ".../dts/collection?id=eco_de_000033",
      "navigation": ".../dts/navigation?resource=eco_de_000033&ref=eco_de_000033_150",
      "document": ".../dts/document?resource=eco_de_000033&ref=eco_de_000033_150"
    }
  ]
}
```

## Index configuration

`data.xconf` is updated to add a Lucene text index on `tei:p`:

```xml
<lucene>
  <text qname="tei:p"/>
</lucene>
```

**Reindex required after deploy** — once the container picks up the new config:

```xquery
xmldb:reindex('/db/ecocor/corpora')
```

Took about a minute for the German corpus (~182 texts) on the dev instance. Until the reindex runs, `ft:query()` returns no results.

## Not included

- **Lemma-aware / annotation-aware search**: searching by lemma or entity category is a natural follow-up. The current endpoint hits surface forms only. The stand-off annotation layers already live under each text's `annotations/` subcollection, so a future search mode can join against the same `tokenized.xml`.
- **Query highlighting** in the KWIC: only plain text is returned. The `kwic` module supports highlighting markup; we could surface it if the frontend needs it.
- **Sort/score**: results come back in Lucene's default relevance order. No explicit sort parameter.

## Test plan

- [ ] `GET /search?q=Nachtigall` returns hits with KWIC and DTS links
- [ ] `GET /search?q=Nachtigall&corpus=de` restricts to corpus
- [ ] `GET /search?q=Nachtigall&id=eco_de_000033` restricts to one text
- [ ] `GET /search?q=...&limit=5&offset=10` paginates correctly
- [ ] Lucene operators work: `q=Nachtigall OR Lerche`, `q="im Wipfel"`, wildcards
- [ ] `GET /search` (no `q`) returns 400
- [ ] `GET /search?q=foo&corpus=nope` returns 404
- [ ] `GET /search?q=foo&id=nope` returns 404
- [ ] Response URLs resolve against the DTS endpoints (once the `dts` PR is merged)
