### PR TITLE
Search metadata

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -23,6 +23,8 @@ tags:
     description: Analyze a text.
   - name: entities
     description: Analyze occurrences of animals and plants in corpora and texts.
+  - name: search
+    description: Full-text search over corpora and texts.
   - name: admin
     description: Manage corpora.
 
@@ -325,6 +327,82 @@ paths:
           description: Returns a plain text document
           content:
             text/plain:
+
+  /search:
+    get:
+      summary: Full-text search across corpora and texts
+      description: >-
+        Paragraph-level Lucene full-text search over the tokenized TEI
+        of every text. Returns hits with KWIC context and URLs into
+        the DTS Collection, Navigation and Document endpoints. The
+        query syntax is Lucene's standard query parser — supports
+        phrases, boolean operators, wildcards, proximity etc.
+
+
+        Optionally restrict to a single corpus with `corpus=<name>` or
+        to a single text with `id=<resource-id>` (the DTS resource id,
+        matching `TEI/@xml:id` with the `_tokenized` suffix stripped).
+      operationId: get-search
+      tags: [search]
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Search query (Lucene syntax)
+          schema:
+            type: string
+          examples:
+            nachtigall:
+              value: Nachtigall
+            phrase:
+              value: '"im Wipfel"'
+            boolean:
+              value: "Nachtigall OR Lerche"
+        - name: corpus
+          in: query
+          required: false
+          description: Restrict search to a single corpus
+          schema:
+            type: string
+          examples:
+            german:
+              value: de
+        - name: id
+          in: query
+          required: false
+          description: >-
+            Restrict search to a single resource. The public DTS
+            resource id (not the internal `_tokenized` form).
+          schema:
+            type: string
+          examples:
+            kleist:
+              value: eco_de_000033
+        - name: limit
+          in: query
+          required: false
+          description: Number of results per page
+          schema:
+            type: integer
+            default: 20
+        - name: offset
+          in: query
+          required: false
+          description: Zero-based offset
+          schema:
+            type: integer
+            default: 0
+      responses:
+        '200':
+          description: Search result page
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchResults'
+        '400':
+          description: Parameter `q` missing
+        '404':
+          description: Corpus or resource not found
 
   /entities/{wikidataId}:
     get:
@@ -678,3 +756,72 @@ components:
         uri:
           type: string
           format: url
+    SearchResults:
+      type: object
+      properties:
+        query:
+          type: string
+        totalHits:
+          type: integer
+        offset:
+          type: integer
+        limit:
+          type: integer
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/SearchHit'
+      required:
+        - query
+        - totalHits
+        - offset
+        - limit
+        - results
+    SearchHit:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Resource id (DTS public form)
+        name:
+          type: string
+          description: Text slug (e.g. 1807_kleist_erdbeben)
+        corpus:
+          type: string
+        title:
+          type: string
+        authors:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+        citableUnit:
+          type: string
+          description: >-
+            Paragraph xml:id — usable as `ref` in DTS Navigation and
+            Document endpoints.
+        kwic:
+          type: string
+          description: Keyword-in-context snippet
+        collection:
+          type: string
+          format: url
+          description: DTS Collection URL for the resource
+        navigation:
+          type: string
+          format: url
+          description: DTS Navigation URL for the matching citable unit
+        document:
+          type: string
+          format: url
+          description: DTS Document URL for the matching citable unit
+      required:
+        - id
+        - name
+        - corpus
+        - title
+        - citableUnit
+        - kwic
+        - document

--- a/api.yaml
+++ b/api.yaml
@@ -404,6 +404,84 @@ paths:
         '404':
           description: Corpus or resource not found
 
+  /search/metadata:
+    get:
+      summary: Search texts by bibliographic metadata
+      description: >-
+        Text-level metadata search over title and author. Returns
+        whole-text hits (not paragraph-level like `/search`). Uses
+        Lucene full-text indexing on `tei:title` and `tei:author`
+        inside the `teiHeader`. Supports Lucene query syntax (phrases,
+        wildcards, boolean operators).
+
+
+        Use `q` to match title OR author. Use `title` / `author` to
+        target one or the other. Filters combine with AND. At least
+        one of `q`, `title`, or `author` is required.
+      operationId: get-search-metadata
+      tags: [search]
+      parameters:
+        - name: q
+          in: query
+          required: false
+          description: Match in title OR author
+          schema:
+            type: string
+          examples:
+            kleist:
+              value: Kleist
+            wildcard:
+              value: "Kleis*"
+        - name: title
+          in: query
+          required: false
+          description: Match in title only
+          schema:
+            type: string
+          examples:
+            erdbeben:
+              value: Erdbeben
+        - name: author
+          in: query
+          required: false
+          description: Match in author names only
+          schema:
+            type: string
+          examples:
+            goethe:
+              value: Goethe
+        - name: corpus
+          in: query
+          required: false
+          description: Restrict search to a single corpus
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          description: Results per page
+          schema:
+            type: integer
+            default: 50
+        - name: offset
+          in: query
+          required: false
+          description: Zero-based offset
+          schema:
+            type: integer
+            default: 0
+      responses:
+        '200':
+          description: Text-level search result page
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MetadataSearchResults'
+        '400':
+          description: No filter parameter supplied
+        '404':
+          description: Corpus not found
+
   /entities/{wikidataId}:
     get:
       summary: Get single entity
@@ -825,3 +903,56 @@ components:
         - citableUnit
         - kwic
         - document
+    MetadataSearchResults:
+      type: object
+      properties:
+        query:
+          type: object
+          description: Echo of the filters that were applied
+        totalHits:
+          type: integer
+        offset:
+          type: integer
+        limit:
+          type: integer
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/MetadataHit'
+      required:
+        - query
+        - totalHits
+        - offset
+        - limit
+        - results
+    MetadataHit:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Resource id (DTS public form)
+        name:
+          type: string
+        corpus:
+          type: string
+        title:
+          type: string
+        authors:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+        uri:
+          type: string
+          format: url
+        collection:
+          type: string
+          format: url
+          description: DTS Collection URL for the resource
+      required:
+        - id
+        - name
+        - corpus
+        - title

--- a/data.xconf
+++ b/data.xconf
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <collection xmlns="http://exist-db.org/collection-config/1.0">
   <index xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tei="http://www.tei-c.org/ns/1.0">
-    <lucene/>
+    <lucene>
+      <text qname="tei:p"/>
+    </lucene>
   </index>
   <triggers>
     <trigger class="org.exist.collections.triggers.XQueryTrigger">

--- a/data.xconf
+++ b/data.xconf
@@ -3,6 +3,8 @@
   <index xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tei="http://www.tei-c.org/ns/1.0">
     <lucene>
       <text qname="tei:p"/>
+      <text qname="tei:title"/>
+      <text qname="tei:author"/>
     </lucene>
   </index>
   <triggers>

--- a/modules/search.xqm
+++ b/modules/search.xqm
@@ -143,3 +143,128 @@ function search:search(
             "results": $results
           }
 };
+
+(:~
+ : Metadata search — title and author substring match across texts.
+ :
+ : Unlike the fulltext /search endpoint (which returns paragraph hits),
+ : this returns text-level hits with bibliographic metadata.
+ :
+ : @param $q Matches in title OR author (substring, case-insensitive)
+ : @param $title Substring match on title
+ : @param $author Substring match on author names
+ : @param $corpus Optional corpus name to restrict search
+ : @param $limit Results per page (default 50)
+ : @param $offset Zero-based offset (default 0)
+ :)
+declare
+  %rest:GET
+  %rest:path("/ecocor/search/metadata")
+  %rest:query-param("q", "{$q}")
+  %rest:query-param("title", "{$title}")
+  %rest:query-param("author", "{$author}")
+  %rest:query-param("corpus", "{$corpus}")
+  %rest:query-param("limit", "{$limit}")
+  %rest:query-param("offset", "{$offset}")
+  %rest:produces("application/json")
+  %output:media-type("application/json")
+  %output:method("json")
+function search:metadata(
+  $q as xs:string*,
+  $title as xs:string*,
+  $author as xs:string*,
+  $corpus as xs:string*,
+  $limit as xs:string*,
+  $offset as xs:string*
+) as item()+ {
+  let $lim := if ($limit) then xs:integer($limit) else 50
+  let $off := if ($offset) then xs:integer($offset) else 0
+
+  let $collection-path :=
+    if ($corpus and $corpus != "")
+    then $config:corpora-root || "/" || $corpus
+    else $config:corpora-root
+
+  return
+    if ($corpus and not(xmldb:collection-available($collection-path))) then
+      (
+        <rest:response><http:response status="404"/></rest:response>,
+        map {
+          "error": "Not Found",
+          "message": "Corpus '" || $corpus || "' does not exist."
+        }
+      )
+    else if (not($q) and not($title) and not($author)) then
+      (
+        <rest:response><http:response status="400"/></rest:response>,
+        map {
+          "error": "Bad Request",
+          "message": "At least one of 'q', 'title', or 'author' is required."
+        }
+      )
+    else
+      let $teis := collection($collection-path)//tei:TEI[@type = "tokenized"]
+
+      (: pre-extract metadata once per TEI so we don't parse twice :)
+      let $matches :=
+        for $tei in $teis
+        let $titles := ectei:get-titles($tei)
+        let $authors := ectei:get-authors($tei)
+        let $title-text := lower-case($titles?main)
+        let $author-text := lower-case(string-join(
+          for $a in $authors return $a?name, " "
+        ))
+        let $q-match :=
+          not($q) or
+          contains($title-text, lower-case($q)) or
+          contains($author-text, lower-case($q))
+        let $title-match :=
+          not($title) or
+          contains($title-text, lower-case($title))
+        let $author-match :=
+          not($author) or
+          contains($author-text, lower-case($author))
+        where $q-match and $title-match and $author-match
+        return map {
+          "tei": $tei,
+          "titles": $titles,
+          "authors": $authors
+        }
+
+      let $total := count($matches)
+      let $page := subsequence($matches, $off + 1, $lim)
+      let $dts-base := $config:api-base || "/dts"
+
+      let $results := array {
+        for $m in $page
+        let $tei := $m?tei
+        let $resource-id := search:resource-id($tei)
+        let $paths := ecutil:filepaths(base-uri($tei))
+        return map {
+          "id": $resource-id,
+          "name": $paths?textname,
+          "corpus": $paths?corpusname,
+          "title": $m?titles?main,
+          "authors": array {
+            for $a in $m?authors return map { "name": $a?name }
+          },
+          "uri": $paths?uri,
+          "collection": $dts-base || "/collection?id=" || $resource-id
+        }
+      }
+
+      return map:merge((
+        map {
+          "query": map:merge((
+            if ($q) then map:entry("q", $q) else (),
+            if ($title) then map:entry("title", $title) else (),
+            if ($author) then map:entry("author", $author) else (),
+            if ($corpus) then map:entry("corpus", $corpus) else ()
+          )),
+          "totalHits": $total,
+          "offset": $off,
+          "limit": $lim,
+          "results": $results
+        }
+      ))
+};

--- a/modules/search.xqm
+++ b/modules/search.xqm
@@ -1,0 +1,145 @@
+xquery version "3.1";
+
+(:~
+ : Full-text search for the EcoCor API.
+ :
+ : Searches the tokenized TEI (`tokenized.xml`) of every text with
+ : Lucene's default analyzer, returning paragraph-level hits with KWIC
+ : context and links into the DTS Collection / Navigation / Document
+ : endpoints.
+ :
+ : Adapted from the ELTeC search module
+ : (https://github.com/clscor-io/eltec-api/blob/main/modules/search.xqm).
+ :)
+module namespace search = "http://ecocor.org/ns/exist/search";
+
+import module namespace config = "http://ecocor.org/ns/exist/config"
+  at "config.xqm";
+import module namespace ectei = "http://ecocor.org/ns/exist/tei"
+  at "tei.xqm";
+import module namespace ecutil = "http://ecocor.org/ns/exist/util"
+  at "util.xqm";
+import module namespace kwic = "http://exist-db.org/xquery/kwic";
+
+declare namespace rest = "http://exquery.org/ns/restxq";
+declare namespace http = "http://expath.org/ns/http-client";
+declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
+declare namespace tei = "http://www.tei-c.org/ns/1.0";
+
+(:~
+ : Public resource id — the tokenized TEI's xml:id with the
+ : `_tokenized` suffix stripped. Matches the DTS Resource id convention.
+ :)
+declare function search:resource-id(
+  $tei as element(tei:TEI)
+) as xs:string {
+  replace(string($tei/@xml:id), '_tokenized$', '')
+};
+
+(:~
+ : Full-text search across the EcoCor corpora.
+ :
+ : @param $q Search query (required, Lucene syntax)
+ : @param $corpus Optional corpus name to restrict search
+ : @param $id Optional resource id (public form, no _tokenized suffix)
+ : @param $limit Results per page (default 20)
+ : @param $offset Zero-based offset (default 0)
+ :)
+declare
+  %rest:GET
+  %rest:path("/ecocor/search")
+  %rest:query-param("q", "{$q}")
+  %rest:query-param("corpus", "{$corpus}")
+  %rest:query-param("id", "{$id}")
+  %rest:query-param("limit", "{$limit}")
+  %rest:query-param("offset", "{$offset}")
+  %rest:produces("application/json")
+  %output:media-type("application/json")
+  %output:method("json")
+function search:search(
+  $q as xs:string*,
+  $corpus as xs:string*,
+  $id as xs:string*,
+  $limit as xs:string*,
+  $offset as xs:string*
+) as item()+ {
+  if (not($q) or $q = "") then
+    (
+      <rest:response><http:response status="400"/></rest:response>,
+      map { "error": "Bad Request", "message": "Parameter 'q' is required." }
+    )
+  else
+
+  let $lim := if ($limit) then xs:integer($limit) else 20
+  let $off := if ($offset) then xs:integer($offset) else 0
+
+  let $collection-path :=
+    if ($corpus and $corpus != "")
+    then $config:corpora-root || "/" || $corpus
+    else $config:corpora-root
+
+  return
+    if ($corpus and not(xmldb:collection-available($collection-path))) then
+      (
+        <rest:response><http:response status="404"/></rest:response>,
+        map {
+          "error": "Not Found",
+          "message": "Corpus '" || $corpus || "' does not exist."
+        }
+      )
+    (: restrict to tokenized TEIs; match resource id via _tokenized suffix :)
+    else
+      let $scope := collection($collection-path)//tei:TEI[@type = "tokenized"]
+      let $scope := if ($id)
+        then $scope[@xml:id = $id || "_tokenized"]
+        else $scope
+      return
+        if ($id and empty($scope)) then
+          (
+            <rest:response><http:response status="404"/></rest:response>,
+            map {
+              "error": "Not Found",
+              "message": "Text '" || $id || "' does not exist."
+            }
+          )
+        else
+          let $hits := $scope//tei:p[ft:query(., $q)]
+          let $total := count($hits)
+          let $page := subsequence($hits, $off + 1, $lim)
+          let $dts-base := $config:api-base || "/dts"
+
+          let $results := array {
+            for $hit in $page
+            let $tei := $hit/ancestor::tei:TEI
+            let $resource-id := search:resource-id($tei)
+            let $titles := ectei:get-titles($tei)
+            let $authors := ectei:get-authors($tei)
+            let $paths := ecutil:filepaths(base-uri($tei))
+            let $cite-ref := string($hit/@xml:id)
+            let $summary := kwic:summarize($hit, <config width="40"/>)
+            return map {
+              "id": $resource-id,
+              "name": $paths?textname,
+              "corpus": $paths?corpusname,
+              "title": $titles?main,
+              "authors": array {
+                for $a in $authors return map { "name": $a?name }
+              },
+              "citableUnit": $cite-ref,
+              "kwic": normalize-space(string-join($summary//text(), " ")),
+              "collection": $dts-base || "/collection?id=" || $resource-id,
+              "navigation": $dts-base || "/navigation?resource=" || $resource-id
+                || "&amp;ref=" || $cite-ref,
+              "document": $dts-base || "/document?resource=" || $resource-id
+                || "&amp;ref=" || $cite-ref
+            }
+          }
+
+          return map {
+            "query": $q,
+            "totalHits": $total,
+            "offset": $off,
+            "limit": $lim,
+            "results": $results
+          }
+};

--- a/modules/search.xqm
+++ b/modules/search.xqm
@@ -205,48 +205,36 @@ function search:metadata(
     else
       let $teis := collection($collection-path)//tei:TEI[@type = "tokenized"]
 
-      (: pre-extract metadata once per TEI so we don't parse twice :)
-      let $matches :=
-        for $tei in $teis
-        let $titles := ectei:get-titles($tei)
-        let $authors := ectei:get-authors($tei)
-        let $title-text := lower-case($titles?main)
-        let $author-text := lower-case(string-join(
-          for $a in $authors return $a?name, " "
-        ))
-        let $q-match :=
-          not($q) or
-          contains($title-text, lower-case($q)) or
-          contains($author-text, lower-case($q))
-        let $title-match :=
-          not($title) or
-          contains($title-text, lower-case($title))
-        let $author-match :=
-          not($author) or
-          contains($author-text, lower-case($author))
-        where $q-match and $title-match and $author-match
-        return map {
-          "tei": $tei,
-          "titles": $titles,
-          "authors": $authors
-        }
+      (: Lucene ft:query on tei:title and tei:author inside titleStmt :)
+      let $matches := $teis[
+        (not($q)
+          or .//tei:titleStmt/tei:title[ft:query(., $q)]
+          or .//tei:titleStmt/tei:author[ft:query(., $q)])
+        and
+        (not($title)
+          or .//tei:titleStmt/tei:title[ft:query(., $title)])
+        and
+        (not($author)
+          or .//tei:titleStmt/tei:author[ft:query(., $author)])
+      ]
 
       let $total := count($matches)
       let $page := subsequence($matches, $off + 1, $lim)
       let $dts-base := $config:api-base || "/dts"
 
       let $results := array {
-        for $m in $page
-        let $tei := $m?tei
+        for $tei in $page
         let $resource-id := search:resource-id($tei)
+        let $titles := ectei:get-titles($tei)
+        let $authors := ectei:get-authors($tei)
         let $paths := ecutil:filepaths(base-uri($tei))
         return map {
           "id": $resource-id,
           "name": $paths?textname,
           "corpus": $paths?corpusname,
-          "title": $m?titles?main,
+          "title": $titles?main,
           "authors": array {
-            for $a in $m?authors return map { "name": $a?name }
+            for $a in $authors return map { "name": $a?name }
           },
           "uri": $paths?uri,
           "collection": $dts-base || "/collection?id=" || $resource-id


### PR DESCRIPTION
# Add /search/metadata endpoint

## Summary

Adds a second search endpoint at `/ecocor/search/metadata` for bibliographic lookup by title and author. Complements the fulltext `/search` (paragraph hits) with text-level hits.

**Stacked on top of [#search](https://github.com/EcoCor/ecocor-api/pull/new/search).** If `search` merges first, this branch becomes a clean main-based PR. Point the PR base at `search` until then, or rebase once `search` lands.

## Design

The search API gains a sub-resource namespace. The sub-path names what you're searching _on_, not what you get back:

```
/search              ← fulltext in paragraphs      — shipped in `search` PR
/search/metadata     ← title + author              — this PR
/search/annotations  ← future
/search/entities     ← future
```

## New endpoint

```
GET /ecocor/search/metadata
```

## Query parameters

| Name | Required | Default | Notes |
|------|----------|---------|-------|
| `q` | one of | — | Match in title OR author |
| `title` | one of | — | Match in title only |
| `author` | one of | — | Match in author names only |
| `corpus` | no | all | Restrict to one corpus |
| `limit` | no | 50 | Results per page |
| `offset` | no | 0 | Zero-based offset |

At least one of `q`, `title`, `author` is required — returns 400 otherwise. Filters combine with AND.

All matching is Lucene-backed (see next section), so wildcards (`Kleis*`), phrases (`"Wilhelm Meister"`), and boolean operators work.

## Index configuration

`data.xconf` adds two Lucene text indices:

```xml
<lucene>
  <text qname="tei:p"/>
  <text qname="tei:title"/>
  <text qname="tei:author"/>
</lucene>
```

The `tei:p` index is shared with `/search` and was introduced in the `search` PR. The `tei:title` and `tei:author` indices are new here.

**Reindex required after deploy**:

```xquery
xmldb:reindex('/db/ecocor/corpora')
```

Took about a minute on the dev instance (182 texts).

## Semantic shift from initial commit

The first commit on this branch used case-insensitive `contains()` substring matching. The follow-up commit switches to `ft:query()`. This matters:

- `q=Kleist` — works both ways (same hit)
- `q=Kleis` — worked with `contains()` (substring match on "Kleist"), doesn't match with Lucene by default. Use `q=Kleis*` for prefix matching.

Lucene's token-boundary semantics is usually what metadata search wants (matching whole names and title words rather than arbitrary character runs). Wildcards are available when substring behaviour is needed.

## Example responses

```
GET /search/metadata?author=Goethe
```

```json
{
  "query": { "author": "Goethe" },
  "totalHits": 3,
  "offset": 0,
  "limit": 50,
  "results": [
    {
      "id": "eco_de_000031",
      "name": "1796_goethe_lehrjahre",
      "corpus": "de",
      "title": "Wilhelm Meisters Lehrjahre",
      "authors": [{ "name": "von Goethe, Johann" }],
      "uri": ".../corpora/de/texts/1796_goethe_lehrjahre",
      "collection": ".../dts/collection?id=eco_de_000031"
    }
  ]
}
```

Combined filters:

```
GET /search/metadata?author=Goethe&title=Wilhelm   → 2 hits
GET /search/metadata?q=Kleis*                      → 1 hit (wildcard)
```

## Not included

- Year range filter (`yearFrom` / `yearTo`) — reserved for a follow-up. The year field has edge cases (`"1807-1808"` ranges) that want more thought.
- Generic annotation search (`/search/annotations`) — same namespace, separate PR.
- Response pagination metadata (`view` / `next` / `prev` links) — returned fields are enough for a simple client; can be added later.

## Test plan

- [ ] `GET /search/metadata?q=Kleist` returns 1 text (title match in Erdbeben)
- [ ] `GET /search/metadata?author=Goethe` returns 3 texts
- [ ] `GET /search/metadata?title=Wilhelm` returns 2 Meister novels
- [ ] `GET /search/metadata?author=Goethe&title=Wilhelm` returns 2 (AND combination)
- [ ] `GET /search/metadata?q=Kleis*` returns the Kleist text (wildcard)
- [ ] `GET /search/metadata?corpus=de&author=Goethe` restricts to corpus
- [ ] `GET /search/metadata` (no filter) returns 400
- [ ] `GET /search/metadata?q=foo&corpus=nope` returns 404
- [ ] Lucene indices persist across a container restart (verify by checking `data.xconf` at `/db/system/config/db/ecocor/corpora/`)
