### PR TITLE
Search tokens

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -23,6 +23,8 @@ tags:
     description: Analyze a text.
   - name: entities
     description: Analyze occurrences of animals and plants in corpora and texts.
+  - name: search
+    description: Full-text search over corpora and texts.
   - name: admin
     description: Manage corpora.
 
@@ -325,6 +327,82 @@ paths:
           description: Returns a plain text document
           content:
             text/plain:
+
+  /search:
+    get:
+      summary: Full-text search across corpora and texts
+      description: >-
+        Paragraph-level Lucene full-text search over the tokenized TEI
+        of every text. Returns hits with KWIC context and URLs into
+        the DTS Collection, Navigation and Document endpoints. The
+        query syntax is Lucene's standard query parser — supports
+        phrases, boolean operators, wildcards, proximity etc.
+
+
+        Optionally restrict to a single corpus with `corpus=<name>` or
+        to a single text with `id=<resource-id>` (the DTS resource id,
+        matching `TEI/@xml:id` with the `_tokenized` suffix stripped).
+      operationId: get-search
+      tags: [search]
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Search query (Lucene syntax)
+          schema:
+            type: string
+          examples:
+            nachtigall:
+              value: Nachtigall
+            phrase:
+              value: '"im Wipfel"'
+            boolean:
+              value: "Nachtigall OR Lerche"
+        - name: corpus
+          in: query
+          required: false
+          description: Restrict search to a single corpus
+          schema:
+            type: string
+          examples:
+            german:
+              value: de
+        - name: id
+          in: query
+          required: false
+          description: >-
+            Restrict search to a single resource. The public DTS
+            resource id (not the internal `_tokenized` form).
+          schema:
+            type: string
+          examples:
+            kleist:
+              value: eco_de_000033
+        - name: limit
+          in: query
+          required: false
+          description: Number of results per page
+          schema:
+            type: integer
+            default: 20
+        - name: offset
+          in: query
+          required: false
+          description: Zero-based offset
+          schema:
+            type: integer
+            default: 0
+      responses:
+        '200':
+          description: Search result page
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchResults'
+        '400':
+          description: Parameter `q` missing
+        '404':
+          description: Corpus or resource not found
 
   /entities/{wikidataId}:
     get:
@@ -678,3 +756,72 @@ components:
         uri:
           type: string
           format: url
+    SearchResults:
+      type: object
+      properties:
+        query:
+          type: string
+        totalHits:
+          type: integer
+        offset:
+          type: integer
+        limit:
+          type: integer
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/SearchHit'
+      required:
+        - query
+        - totalHits
+        - offset
+        - limit
+        - results
+    SearchHit:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Resource id (DTS public form)
+        name:
+          type: string
+          description: Text slug (e.g. 1807_kleist_erdbeben)
+        corpus:
+          type: string
+        title:
+          type: string
+        authors:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+        citableUnit:
+          type: string
+          description: >-
+            Paragraph xml:id — usable as `ref` in DTS Navigation and
+            Document endpoints.
+        kwic:
+          type: string
+          description: Keyword-in-context snippet
+        collection:
+          type: string
+          format: url
+          description: DTS Collection URL for the resource
+        navigation:
+          type: string
+          format: url
+          description: DTS Navigation URL for the matching citable unit
+        document:
+          type: string
+          format: url
+          description: DTS Document URL for the matching citable unit
+      required:
+        - id
+        - name
+        - corpus
+        - title
+        - citableUnit
+        - kwic
+        - document

--- a/api.yaml
+++ b/api.yaml
@@ -409,13 +409,17 @@ paths:
       summary: Search tokens by surface form
       description: >-
         Full-text search over `<w>` tokens in the tokenized TEI. Each
-        hit includes the list of annotations that target that token
-        (from any layer) — so the client can see **which layers detected
-        it**, by which `layerType`, and with what body.
+        hit includes the list of annotations that target the token
+        (from any layer) — so the client can see **which layers
+        detected it**, by which `layerType`, and with what body.
 
 
-        The optional `annotated` flag filters results to tokens that
-        have at least one annotation (`true`) or none (`false`).
+        The optional `layerType` filter narrows results to tokens that
+        carry an annotation from at least one layer whose
+        `listAnnotation/@type` equals the given value. For entity-type
+        queries, use `layerType=entities` — this excludes the
+        linguistic layer (which annotates every token) so the result
+        reflects what entity taggers actually caught.
 
 
         Uses Lucene full-text indexing on `tei:w`. Standard Lucene
@@ -437,16 +441,20 @@ paths:
               value: "Biber*"
             phrase:
               value: '"guter Mann"'
-        - name: annotated
+        - name: layerType
           in: query
           required: false
           description: >-
-            Filter by annotation presence. `true` keeps only tokens
-            with at least one annotation, `false` keeps only tokens
-            with none. Omit to return all matches.
+            Filter to tokens annotated by at least one layer whose
+            `listAnnotation/@type` matches this value. `entities` is
+            the common case (excludes the linguistic layer).
           schema:
             type: string
-            enum: [true, false]
+          examples:
+            entities:
+              value: entities
+            linguistic:
+              value: linguistic
         - name: corpus
           in: query
           required: false
@@ -481,7 +489,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/TokenSearchResults'
         '400':
-          description: Parameter `q` missing or `annotated` invalid
+          description: Parameter `q` missing
         '404':
           description: Corpus or resource not found
 

--- a/api.yaml
+++ b/api.yaml
@@ -404,6 +404,87 @@ paths:
         '404':
           description: Corpus or resource not found
 
+  /search/tokens:
+    get:
+      summary: Search tokens by surface form
+      description: >-
+        Full-text search over `<w>` tokens in the tokenized TEI. Each
+        hit includes the list of annotations that target that token
+        (from any layer) — so the client can see **which layers detected
+        it**, by which `layerType`, and with what body.
+
+
+        The optional `annotated` flag filters results to tokens that
+        have at least one annotation (`true`) or none (`false`).
+
+
+        Uses Lucene full-text indexing on `tei:w`. Standard Lucene
+        syntax — wildcards like `Biber*` catch inflections and
+        compounds ("Biber", "Bibern", "Biberrepublik", …).
+      operationId: get-search-tokens
+      tags: [search]
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Surface-form query (Lucene syntax)
+          schema:
+            type: string
+          examples:
+            exact:
+              value: Biber
+            wildcard:
+              value: "Biber*"
+            phrase:
+              value: '"guter Mann"'
+        - name: annotated
+          in: query
+          required: false
+          description: >-
+            Filter by annotation presence. `true` keeps only tokens
+            with at least one annotation, `false` keeps only tokens
+            with none. Omit to return all matches.
+          schema:
+            type: string
+            enum: [true, false]
+        - name: corpus
+          in: query
+          required: false
+          description: Restrict to a single corpus
+          schema:
+            type: string
+        - name: id
+          in: query
+          required: false
+          description: Restrict to a single resource (DTS public id)
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          description: Results per page
+          schema:
+            type: integer
+            default: 20
+        - name: offset
+          in: query
+          required: false
+          description: Zero-based offset
+          schema:
+            type: integer
+            default: 0
+      responses:
+        '200':
+          description: Token search results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenSearchResults'
+        '400':
+          description: Parameter `q` missing or `annotated` invalid
+        '404':
+          description: Corpus or resource not found
+
   /entities/{wikidataId}:
     get:
       summary: Get single entity
@@ -825,3 +906,107 @@ components:
         - citableUnit
         - kwic
         - document
+    TokenSearchResults:
+      type: object
+      properties:
+        query:
+          type: object
+          description: Echo of the parameters that were applied
+        totalHits:
+          type: integer
+        offset:
+          type: integer
+        limit:
+          type: integer
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/TokenSearchHit'
+      required:
+        - query
+        - totalHits
+        - offset
+        - limit
+        - results
+    TokenSearchHit:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Resource id (DTS public form)
+        name:
+          type: string
+        corpus:
+          type: string
+        token:
+          type: object
+          properties:
+            id:
+              type: string
+            text:
+              type: string
+              description: Surface form
+            type:
+              type: string
+              enum: [w, pc]
+          required:
+            - id
+            - text
+            - type
+        citableUnit:
+          type: string
+          description: >-
+            Containing paragraph xml:id — usable as `ref` in the DTS
+            Navigation / Document endpoints.
+        annotations:
+          type: array
+          description: >-
+            All annotations targeting this token, flattened across
+            layers. Each entry carries the layer name, the layer's
+            `listAnnotation/@type` (semantic kind — `entities`,
+            `linguistic`, …), and a body of key/value pairs from the
+            annotation attributes and notes.
+          items:
+            type: object
+            properties:
+              layer:
+                type: string
+                description: Layer name (filename without .xml)
+              layerType:
+                type: string
+                description: >-
+                  From `listAnnotation/@type`. Multiple layers can share
+                  a type (e.g. `dictionarylookup` and `ntee` both have
+                  `layerType=entities`).
+              body:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    key:
+                      type: string
+                    value:
+                      type: string
+                  required:
+                    - key
+                    - value
+            required:
+              - layer
+              - layerType
+              - body
+        tokenUri:
+          type: string
+          format: url
+          description: Link to the single-token endpoint
+        document:
+          type: string
+          format: url
+          description: >-
+            DTS Document URL pointing at the containing paragraph.
+            Absent if the token is not inside a `<p>` with an xml:id.
+      required:
+        - id
+        - name
+        - corpus
+        - token
+        - annotations

--- a/data.xconf
+++ b/data.xconf
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <collection xmlns="http://exist-db.org/collection-config/1.0">
   <index xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tei="http://www.tei-c.org/ns/1.0">
-    <lucene/>
+    <lucene>
+      <text qname="tei:p"/>
+    </lucene>
   </index>
   <triggers>
     <trigger class="org.exist.collections.triggers.XQueryTrigger">

--- a/data.xconf
+++ b/data.xconf
@@ -3,6 +3,7 @@
   <index xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tei="http://www.tei-c.org/ns/1.0">
     <lucene>
       <text qname="tei:p"/>
+      <text qname="tei:w"/>
     </lucene>
   </index>
   <triggers>

--- a/modules/search.xqm
+++ b/modules/search.xqm
@@ -143,3 +143,216 @@ function search:search(
             "results": $results
           }
 };
+
+(:~
+ : Token-surface search. Finds `<w>` tokens matching a Lucene query,
+ : optionally filtered to tokens that have (or don't have) any
+ : annotation from any layer.
+ :
+ : Each result carries the list of annotations on the token — clients
+ : see which layers detected the token (and the annotation body
+ : key/value pairs).
+ :
+ : @param $q Surface-form query (Lucene syntax, required)
+ : @param $annotated "true" / "false" to filter by annotation presence;
+ :                    omit to return all matches
+ : @param $corpus Optional corpus name
+ : @param $id Optional resource id (public form)
+ : @param $limit Results per page (default 20)
+ : @param $offset Zero-based offset (default 0)
+ :)
+declare
+  %rest:GET
+  %rest:path("/ecocor/search/tokens")
+  %rest:query-param("q", "{$q}")
+  %rest:query-param("annotated", "{$annotated}")
+  %rest:query-param("corpus", "{$corpus}")
+  %rest:query-param("id", "{$id}")
+  %rest:query-param("limit", "{$limit}")
+  %rest:query-param("offset", "{$offset}")
+  %rest:produces("application/json")
+  %output:media-type("application/json")
+  %output:method("json")
+function search:tokens(
+  $q as xs:string*,
+  $annotated as xs:string*,
+  $corpus as xs:string*,
+  $id as xs:string*,
+  $limit as xs:string*,
+  $offset as xs:string*
+) as item()+ {
+  if (not($q) or $q = "") then
+    (
+      <rest:response><http:response status="400"/></rest:response>,
+      map { "error": "Bad Request", "message": "Parameter 'q' is required." }
+    )
+  else if ($annotated and not($annotated = ("true", "false"))) then
+    (
+      <rest:response><http:response status="400"/></rest:response>,
+      map {
+        "error": "Bad Request",
+        "message": "Parameter 'annotated' must be 'true' or 'false'."
+      }
+    )
+  else
+
+  let $lim := if ($limit) then xs:integer($limit) else 20
+  let $off := if ($offset) then xs:integer($offset) else 0
+
+  let $collection-path :=
+    if ($corpus and $corpus != "")
+    then $config:corpora-root || "/" || $corpus
+    else $config:corpora-root
+
+  return
+    if ($corpus and not(xmldb:collection-available($collection-path))) then
+      (
+        <rest:response><http:response status="404"/></rest:response>,
+        map {
+          "error": "Not Found",
+          "message": "Corpus '" || $corpus || "' does not exist."
+        }
+      )
+    else
+      let $scope := collection($collection-path)//tei:TEI[@type = "tokenized"]
+      let $scope := if ($id)
+        then $scope[@xml:id = $id || "_tokenized"]
+        else $scope
+      return
+        if ($id and empty($scope)) then
+          (
+            <rest:response><http:response status="404"/></rest:response>,
+            map {
+              "error": "Not Found",
+              "message": "Text '" || $id || "' does not exist."
+            }
+          )
+        else
+          let $all-hits := $scope//tei:w[ft:query(., $q)]
+
+          (: annotation filter: keep/drop tokens that have annotations :)
+          let $filtered := if ($annotated = "true") then
+            $all-hits[search:has-annotation(.)]
+          else if ($annotated = "false") then
+            $all-hits[not(search:has-annotation(.))]
+          else
+            $all-hits
+
+          let $total := count($filtered)
+          let $page := subsequence($filtered, $off + 1, $lim)
+          let $dts-base := $config:api-base || "/dts"
+
+          let $results := array {
+            for $hit in $page
+            let $tei := $hit/ancestor::tei:TEI
+            let $resource-id := search:resource-id($tei)
+            let $paths := ecutil:filepaths(base-uri($tei))
+            let $token-id := string($hit/@xml:id)
+            let $paragraph := $hit/ancestor::tei:p[@xml:id][1]
+            let $cite-ref := if ($paragraph)
+              then string($paragraph/@xml:id)
+              else ()
+            return map:merge((
+              map {
+                "id": $resource-id,
+                "name": $paths?textname,
+                "corpus": $paths?corpusname,
+                "token": map {
+                  "id": $token-id,
+                  "text": string($hit),
+                  "type": local-name($hit)
+                },
+                "annotations": search:annotations-for-token($tei, $token-id)
+              },
+              if ($cite-ref) then (
+                map:entry("citableUnit", $cite-ref),
+                map:entry(
+                  "document",
+                  $dts-base || "/document?resource=" || $resource-id
+                    || "&amp;ref=" || $cite-ref
+                )
+              ) else (),
+              map:entry(
+                "tokenUri",
+                $paths?uri || "/tokens/" || $token-id
+              )
+            ))
+          }
+
+          return map:merge((
+            map {
+              "query": map:merge((
+                map:entry("q", $q),
+                if ($annotated) then map:entry("annotated", $annotated) else (),
+                if ($corpus) then map:entry("corpus", $corpus) else (),
+                if ($id) then map:entry("id", $id) else ()
+              )),
+              "totalHits": $total,
+              "offset": $off,
+              "limit": $lim,
+              "results": $results
+            }
+          ))
+};
+
+(:~
+ : True if the token (its xml:id) is referenced by any annotation in
+ : any layer of the containing text's annotations/ subcollection.
+ :)
+declare function search:has-annotation(
+  $token as element(tei:w)
+) as xs:boolean {
+  let $tei := $token/ancestor::tei:TEI
+  let $segments := tokenize(base-uri($tei), '/')
+  let $text-collection := string-join($segments[position() < last()], "/")
+  let $ann-collection := $text-collection || "/annotations"
+  return
+    if (not(xmldb:collection-available($ann-collection))) then false()
+    else
+      let $target-ref := "#" || string($token/@xml:id)
+      return exists(
+        collection($ann-collection)//tei:annotation[
+          tokenize(@target, '\s+') = $target-ref
+        ]
+      )
+};
+
+(:~
+ : Annotations (flat across layers) targeting a given token id. Each
+ : entry carries the source layer name and a body of key/value pairs.
+ :)
+declare function search:annotations-for-token(
+  $tei as element(tei:TEI),
+  $token-id as xs:string
+) as array(*) {
+  let $segments := tokenize(base-uri($tei), '/')
+  let $text-collection := string-join($segments[position() < last()], "/")
+  let $ann-collection := $text-collection || "/annotations"
+  let $target-ref := "#" || $token-id
+  return array {
+    if (not(xmldb:collection-available($ann-collection))) then () else
+    for $resource in xmldb:get-child-resources($ann-collection)
+    let $doc := doc($ann-collection || "/" || $resource)
+    let $layername := replace($resource, '\.xml$', '')
+    let $layer-type := string($doc//tei:listAnnotation/@type)
+    for $a in $doc//tei:annotation[
+      tokenize(@target, '\s+') = $target-ref
+    ]
+    return map {
+      "layer": $layername,
+      "layerType": $layer-type,
+      "body": array {
+        for $attr in $a/(@ana, @corresp)
+        return map {
+          "key": local-name($attr),
+          "value": string($attr)
+        },
+        for $note in $a/tei:note[@type]
+        return map {
+          "key": string($note/@type),
+          "value": normalize-space($note)
+        }
+      }
+    }
+  }
+};

--- a/modules/search.xqm
+++ b/modules/search.xqm
@@ -1,0 +1,145 @@
+xquery version "3.1";
+
+(:~
+ : Full-text search for the EcoCor API.
+ :
+ : Searches the tokenized TEI (`tokenized.xml`) of every text with
+ : Lucene's default analyzer, returning paragraph-level hits with KWIC
+ : context and links into the DTS Collection / Navigation / Document
+ : endpoints.
+ :
+ : Adapted from the ELTeC search module
+ : (https://github.com/clscor-io/eltec-api/blob/main/modules/search.xqm).
+ :)
+module namespace search = "http://ecocor.org/ns/exist/search";
+
+import module namespace config = "http://ecocor.org/ns/exist/config"
+  at "config.xqm";
+import module namespace ectei = "http://ecocor.org/ns/exist/tei"
+  at "tei.xqm";
+import module namespace ecutil = "http://ecocor.org/ns/exist/util"
+  at "util.xqm";
+import module namespace kwic = "http://exist-db.org/xquery/kwic";
+
+declare namespace rest = "http://exquery.org/ns/restxq";
+declare namespace http = "http://expath.org/ns/http-client";
+declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
+declare namespace tei = "http://www.tei-c.org/ns/1.0";
+
+(:~
+ : Public resource id — the tokenized TEI's xml:id with the
+ : `_tokenized` suffix stripped. Matches the DTS Resource id convention.
+ :)
+declare function search:resource-id(
+  $tei as element(tei:TEI)
+) as xs:string {
+  replace(string($tei/@xml:id), '_tokenized$', '')
+};
+
+(:~
+ : Full-text search across the EcoCor corpora.
+ :
+ : @param $q Search query (required, Lucene syntax)
+ : @param $corpus Optional corpus name to restrict search
+ : @param $id Optional resource id (public form, no _tokenized suffix)
+ : @param $limit Results per page (default 20)
+ : @param $offset Zero-based offset (default 0)
+ :)
+declare
+  %rest:GET
+  %rest:path("/ecocor/search")
+  %rest:query-param("q", "{$q}")
+  %rest:query-param("corpus", "{$corpus}")
+  %rest:query-param("id", "{$id}")
+  %rest:query-param("limit", "{$limit}")
+  %rest:query-param("offset", "{$offset}")
+  %rest:produces("application/json")
+  %output:media-type("application/json")
+  %output:method("json")
+function search:search(
+  $q as xs:string*,
+  $corpus as xs:string*,
+  $id as xs:string*,
+  $limit as xs:string*,
+  $offset as xs:string*
+) as item()+ {
+  if (not($q) or $q = "") then
+    (
+      <rest:response><http:response status="400"/></rest:response>,
+      map { "error": "Bad Request", "message": "Parameter 'q' is required." }
+    )
+  else
+
+  let $lim := if ($limit) then xs:integer($limit) else 20
+  let $off := if ($offset) then xs:integer($offset) else 0
+
+  let $collection-path :=
+    if ($corpus and $corpus != "")
+    then $config:corpora-root || "/" || $corpus
+    else $config:corpora-root
+
+  return
+    if ($corpus and not(xmldb:collection-available($collection-path))) then
+      (
+        <rest:response><http:response status="404"/></rest:response>,
+        map {
+          "error": "Not Found",
+          "message": "Corpus '" || $corpus || "' does not exist."
+        }
+      )
+    (: restrict to tokenized TEIs; match resource id via _tokenized suffix :)
+    else
+      let $scope := collection($collection-path)//tei:TEI[@type = "tokenized"]
+      let $scope := if ($id)
+        then $scope[@xml:id = $id || "_tokenized"]
+        else $scope
+      return
+        if ($id and empty($scope)) then
+          (
+            <rest:response><http:response status="404"/></rest:response>,
+            map {
+              "error": "Not Found",
+              "message": "Text '" || $id || "' does not exist."
+            }
+          )
+        else
+          let $hits := $scope//tei:p[ft:query(., $q)]
+          let $total := count($hits)
+          let $page := subsequence($hits, $off + 1, $lim)
+          let $dts-base := $config:api-base || "/dts"
+
+          let $results := array {
+            for $hit in $page
+            let $tei := $hit/ancestor::tei:TEI
+            let $resource-id := search:resource-id($tei)
+            let $titles := ectei:get-titles($tei)
+            let $authors := ectei:get-authors($tei)
+            let $paths := ecutil:filepaths(base-uri($tei))
+            let $cite-ref := string($hit/@xml:id)
+            let $summary := kwic:summarize($hit, <config width="40"/>)
+            return map {
+              "id": $resource-id,
+              "name": $paths?textname,
+              "corpus": $paths?corpusname,
+              "title": $titles?main,
+              "authors": array {
+                for $a in $authors return map { "name": $a?name }
+              },
+              "citableUnit": $cite-ref,
+              "kwic": normalize-space(string-join($summary//text(), " ")),
+              "collection": $dts-base || "/collection?id=" || $resource-id,
+              "navigation": $dts-base || "/navigation?resource=" || $resource-id
+                || "&amp;ref=" || $cite-ref,
+              "document": $dts-base || "/document?resource=" || $resource-id
+                || "&amp;ref=" || $cite-ref
+            }
+          }
+
+          return map {
+            "query": $q,
+            "totalHits": $total,
+            "offset": $off,
+            "limit": $lim,
+            "results": $results
+          }
+};

--- a/modules/search.xqm
+++ b/modules/search.xqm
@@ -146,16 +146,16 @@ function search:search(
 
 (:~
  : Token-surface search. Finds `<w>` tokens matching a Lucene query,
- : optionally filtered to tokens that have (or don't have) any
- : annotation from any layer.
+ : optionally filtered to tokens that carry an annotation from a layer
+ : of a given `listAnnotation/@type` (e.g. `entities`).
  :
- : Each result carries the list of annotations on the token — clients
- : see which layers detected the token (and the annotation body
- : key/value pairs).
+ : Each result carries the list of annotations on the token across all
+ : layers — so clients see which layers detected it and with what body.
  :
  : @param $q Surface-form query (Lucene syntax, required)
- : @param $annotated "true" / "false" to filter by annotation presence;
- :                    omit to return all matches
+ : @param $layerType Restrict to tokens annotated by a layer whose
+ :                   `listAnnotation/@type` equals this value (e.g.
+ :                   "entities"). Omit to return all matches.
  : @param $corpus Optional corpus name
  : @param $id Optional resource id (public form)
  : @param $limit Results per page (default 20)
@@ -165,7 +165,7 @@ declare
   %rest:GET
   %rest:path("/ecocor/search/tokens")
   %rest:query-param("q", "{$q}")
-  %rest:query-param("annotated", "{$annotated}")
+  %rest:query-param("layerType", "{$layerType}")
   %rest:query-param("corpus", "{$corpus}")
   %rest:query-param("id", "{$id}")
   %rest:query-param("limit", "{$limit}")
@@ -175,7 +175,7 @@ declare
   %output:method("json")
 function search:tokens(
   $q as xs:string*,
-  $annotated as xs:string*,
+  $layerType as xs:string*,
   $corpus as xs:string*,
   $id as xs:string*,
   $limit as xs:string*,
@@ -185,14 +185,6 @@ function search:tokens(
     (
       <rest:response><http:response status="400"/></rest:response>,
       map { "error": "Bad Request", "message": "Parameter 'q' is required." }
-    )
-  else if ($annotated and not($annotated = ("true", "false"))) then
-    (
-      <rest:response><http:response status="400"/></rest:response>,
-      map {
-        "error": "Bad Request",
-        "message": "Parameter 'annotated' must be 'true' or 'false'."
-      }
     )
   else
 
@@ -230,11 +222,10 @@ function search:tokens(
         else
           let $all-hits := $scope//tei:w[ft:query(., $q)]
 
-          (: annotation filter: keep/drop tokens that have annotations :)
-          let $filtered := if ($annotated = "true") then
-            $all-hits[search:has-annotation(.)]
-          else if ($annotated = "false") then
-            $all-hits[not(search:has-annotation(.))]
+          (: layer-type filter: keep only tokens with ≥1 annotation from
+             a layer where listAnnotation/@type = $layerType :)
+          let $filtered := if ($layerType) then
+            $all-hits[search:has-annotation-of-type(., $layerType)]
           else
             $all-hits
 
@@ -283,7 +274,7 @@ function search:tokens(
             map {
               "query": map:merge((
                 map:entry("q", $q),
-                if ($annotated) then map:entry("annotated", $annotated) else (),
+                if ($layerType) then map:entry("layerType", $layerType) else (),
                 if ($corpus) then map:entry("corpus", $corpus) else (),
                 if ($id) then map:entry("id", $id) else ()
               )),
@@ -296,11 +287,12 @@ function search:tokens(
 };
 
 (:~
- : True if the token (its xml:id) is referenced by any annotation in
- : any layer of the containing text's annotations/ subcollection.
+ : True if the token carries at least one annotation from a layer
+ : whose `listAnnotation/@type` equals `$layer-type`.
  :)
-declare function search:has-annotation(
-  $token as element(tei:w)
+declare function search:has-annotation-of-type(
+  $token as element(tei:w),
+  $layer-type as xs:string
 ) as xs:boolean {
   let $tei := $token/ancestor::tei:TEI
   let $segments := tokenize(base-uri($tei), '/')
@@ -311,9 +303,9 @@ declare function search:has-annotation(
     else
       let $target-ref := "#" || string($token/@xml:id)
       return exists(
-        collection($ann-collection)//tei:annotation[
-          tokenize(@target, '\s+') = $target-ref
-        ]
+        collection($ann-collection)
+          //tei:listAnnotation[@type = $layer-type]
+          //tei:annotation[tokenize(@target, '\s+') = $target-ref]
       )
 };
 


### PR DESCRIPTION
# Add /search/tokens endpoint

## Summary

Adds a third search endpoint at `/ecocor/search/tokens` that searches token surface forms with an annotation-aware filter. Answers the cross-layer question "has **any** annotation tool flagged this word as an entity in **any** text?" in a single request.

**Stacked on [#search](https://github.com/EcoCor/ecocor-api/pull/new/search).** Point the PR base at `search` until it merges; rebase onto `main` afterwards.

## Design

Sub-resource namespace continues to grow under `/search`:

```
/search              ← fulltext in paragraphs       — shipped in `search` PR
/search/tokens       ← tokens by surface form       — this PR
/search/metadata     ← texts by title/author        — separate PR (#search-metadata)
/search/annotations  ← future
```

## New endpoint

```
GET /ecocor/search/tokens
```

## Query parameters

| Name | Required | Default | Notes |
|------|----------|---------|-------|
| `q` | yes | — | Surface-form query (Lucene syntax, wildcards OK) |
| `layerType` | no | — | Restrict to tokens annotated by a layer whose `listAnnotation/@type` matches. Use `entities` to ignore the linguistic layer. |
| `corpus` | no | all | Restrict to one corpus |
| `id` | no | all | Restrict to one resource (DTS public id) |
| `limit` | no | 20 | Results per page |
| `offset` | no | 0 | Zero-based offset |

## Design note: why `layerType` instead of a plain `annotated` flag

Early draft of this branch had `annotated=true|false`. Turns out it's not useful in practice: the linguistic layer annotates **every** token, so `annotated=true` matches everything with a linguistic layer present, and `annotated=false` matches nothing. The naming made it look more discriminating than it was.

Replaced with `layerType=<listAnnotation/@type>`. Users ask the sharper question "annotated *as what*?" and the linguistic layer can be excluded cleanly. `layerType=entities` is the common case.

## Response

Per-token hits. Each carries **all** annotations on the token (not just the filter-matching ones) so the client can see across layers:

```json
{
  "query": { "q": "Biber*", "layerType": "entities" },
  "totalHits": 1,
  "offset": 0,
  "limit": 20,
  "results": [
    {
      "id": "eco_de_000062",
      "name": "1813_goethe_italienische-reise",
      "corpus": "de",
      "token": {
        "id": "eco_de_000062_3080_0500",
        "text": "Biberrepublik",
        "type": "w"
      },
      "citableUnit": "eco_de_000062_3080",
      "annotations": [
        {
          "layer": "linguistic",
          "layerType": "linguistic",
          "body": [
            { "key": "ana", "value": "#stts-NN" },
            { "key": "lemma", "value": "Biberrepublik" }
          ]
        },
        {
          "layer": "ntee",
          "layerType": "entities",
          "body": [
            { "key": "ana", "value": "#cat-habitat" }
          ]
        }
      ],
      "tokenUri": ".../corpora/de/texts/1813_goethe_italienische-reise/tokens/eco_de_000062_3080_0500",
      "document": ".../dts/document?resource=eco_de_000062&ref=eco_de_000062_3080"
    }
  ]
}
```

## Worked example (real data)

Research question: *"Has any annotation tool flagged a beaver (Biber) anywhere in the German EcoCor?"*

```
GET /search/tokens?q=Biber*                          → 15 hits
```

Eight surface forms: Biber, Bibern, Biberhut, Biberfell, Biberfelle, Biberjäger, Biberinsel, Biberrepublik.

```
GET /search/tokens?q=Biber*&layerType=entities       → 1 hit
```

Only "Biberrepublik" in Goethe's *Italienische Reise* — and it was flagged by the manual `ntee` layer (category `cat-habitat`), not by the automated `dictionarylookup`. Every other Biber* mention, including the six plain "Biber"s, went un-flagged by the entity taggers.

## Index configuration

`data.xconf` gains a Lucene text index on `tei:w`:

```xml
<lucene>
  <text qname="tei:p"/>
  <text qname="tei:w"/>
</lucene>
```

**Reindex required after deploy**:

```xquery
xmldb:reindex('/db/ecocor/corpora')
```

## Not included

- No `category`, `layer`, or `corresp` (Wikidata) filters yet — those can go on in a follow-up once someone asks. `layerType` covers the common cases.
- No lemma-aware search (e.g. "find all forms of *fliegen*"). The linguistic layer has the data but the join isn't wired up yet.
- No grouping in the response (e.g. "Biber-related mentions grouped by Wikidata Q-id") — callers group client-side for now.

## Test plan

- [ ] `GET /search/tokens?q=Biber` returns 6 hits (plain "Biber")
- [ ] `GET /search/tokens?q=Biber*` returns 15 hits (inflections + compounds)
- [ ] `GET /search/tokens?q=Biber*&layerType=entities` returns 1 hit (Biberrepublik / ntee)
- [ ] `GET /search/tokens?q=Biber*&layerType=linguistic` returns all 15 (linguistic layer annotates every token)
- [ ] `GET /search/tokens?q=Biber*&corpus=de` restricts to corpus
- [ ] `GET /search/tokens?q=Biber*&id=eco_de_000062` restricts to one text
- [ ] `GET /search/tokens` (no `q`) returns 400
- [ ] `GET /search/tokens?q=foo&corpus=nope` returns 404
- [ ] The `annotations` array in each hit includes **all** annotations on the token (not only filter-matching ones), so the client can see cross-layer coverage
